### PR TITLE
Add rules related to string

### DIFF
--- a/.vscode/typescript-common.code-snippets
+++ b/.vscode/typescript-common.code-snippets
@@ -4,6 +4,11 @@
     "scope": "typescript",
     "body": ["export { $2 } from \"${1:module}\";"]
   },
+  "Import modules from @shared": {
+    "prefix": "import shared",
+    "scope": "typescript",
+    "body": ["import { $2 } from \"@shared/${1:index}\";"]
+  },
   "Import modules from @checkers": {
     "prefix": "import checkers",
     "scope": "typescript",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ import marubatsu from "marubatsu";
 const website = "https://example.com";
 const isValidWebsite = marubatsu()
   .present()
-  .string({ length: [7, 128], startsWith: ["http://", "https://"] })
+  .string({ length: [7, 128] })
+  .or(
+    (validator) => validator().string({ startsWith: "http://" }),
+    (validator) => validator().string({ startsWith: "https://" }),
+  )
   .not.string({ endsWith: "/" })
   .test(website); // true
 ```
@@ -496,7 +500,7 @@ const websiteIdentifierValidator = marubatsu()
   .string({ length: [4, 255] });
 
 const urlValidator = websiteIdentifierValidator
-  .string({ minimumLength: false, startsWith: ["http", "https"] });
+  .string({ minimumLength: false, startsWith: "https" });
   // Disable `minimumLength` and merge `startsWith` rule
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ const isValidWebsite = marubatsu()
     - [`minimumLength: number`](#minimumlength-number)
     - [`startsWith: number | string`](#startswith-number--string)
     - [`endsWith: number | string`](#endswith-number--string)
+    - [`alphanumeric: boolean`](#alphanumeric-boolean)
+    - [`alphanumeric: "lower-camel" | "upper-camel" | "lower-snake" | "upper-snake" | "lower-kebab" | "upper-kebab" | "lower-space" | "upper-space" | "lower-dot" | "upper-dot"`](#alphanumeric-lower-camel--upper-camel--lower-snake--upper-snake--lower-kebab--upper-kebab--lower-space--upper-space--lower-dot--upper-dot)
     - [`includes: number | string`](#includes-number--string)
     - [`pattern: RegExp`](#pattern-regexp)
 - [Options](#options)
@@ -367,6 +369,47 @@ const validator = marubatsu().string({ endsWith: 1 });
 validator.test("123"); // false
 validator.test("231"); // true
 validator.test("321"); // true
+```
+
+#### `alphanumeric: boolean`
+Checks the string is alphanumeric.
+
+```ts
+const validator = marubatsu().string({ alphanumeric: true });
+
+validator.test("123"); // true
+validator.test("abc"); // true
+validator.test("a12"); // true
+validator.test("# @"); // false
+```
+
+#### `alphanumeric: "lower-camel" | "upper-camel" | "lower-snake" | "upper-snake" | "lower-kebab" | "upper-kebab" | "lower-space" | "upper-space" | "lower-dot" | "upper-dot"`
+Checks the string is alphanumeric and a specific case style such as `lowerCamelCase` or `lower_snake_case` .
+
+You can specify one of the following case style.
+
+| VALUE           | CASE STYLE                          | VALID STRING         |
+|-----------------|-------------------------------------|----------------------|
+| `"lower-camel"` | Lower Camel Case                    | `"lowerCamelCase"`   |
+| `"upper-camel"` | Upper Camel Case                    | `"UpperCamelCase"`   |
+| `"lower-snake"` | Lower Snake Case                    | `"lower_snake_case"` |
+| `"upper-snake"` | Upper Snake Case                    | `"Upper_Snake_Case"` |
+| `"lower-kebab"` | Lower Kebab Case (Lower Chain Case) | `"lower-kebab-case"` |
+| `"upper-kebab"` | Upper Kebab Case (Upper Chain Case) | `"Upper-Kebab-Case"` |
+| `"lower-space"` | Lower Space Case                    | `"lower space case"` |
+| `"upper-space"` | Upper Space Case                    | `"Upper Space Case"` |
+| `"lower-dot"`   | Lower Dot Case                      | `"lower.dot.case"`   |
+| `"upper-dot"`   | Upper Dot Case                      | `"Upper.Dot.Case"`   |
+
+```ts
+const validator = marubatsu().string({ alphanumeric: "lower-snake" });
+
+validator.test("jagaapple");  // true
+validator.test("jaga_apple"); // true
+validator.test("JagaApple");  // false
+validator.test("Jaga Apple"); // false
+validator.test("jaga-apple"); // false
+validator.test("jaga.apple"); // false
 ```
 
 #### `includes: number | string`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const isValidWebsite = marubatsu()
     - [`minimumLength: number`](#minimumlength-number)
     - [`startsWith: number | string`](#startswith-number--string)
     - [`endsWith: number | string`](#endswith-number--string)
-    - [`includes: string`](#includes-string)
+    - [`includes: number | string`](#includes-number--string)
     - [`pattern: RegExp`](#pattern-regexp)
 - [Options](#options)
     - [`checkAll: boolean = false`](#checkall-boolean--false)
@@ -348,7 +348,7 @@ validator.test("1234"); // true
 
 
 #### `startsWith: number | string`
-Checks the string is starting with a specific number or string. If passing number, it will be converted to string value.
+Checks the string is starting with a specific number or string. If passing number, it will be converted to string.
 
 ```ts
 const validator = marubatsu().string({ startsWith: 1 });
@@ -359,7 +359,7 @@ validator.test("321"); // false
 ```
 
 #### `endsWith: number | string`
-Checks the string is ending with a specific number or string. If passing number, it will be converted to string value.
+Checks the string is ending with a specific number or string. If passing number, it will be converted to string.
 
 ```ts
 const validator = marubatsu().string({ endsWith: 1 });
@@ -369,8 +369,8 @@ validator.test("231"); // true
 validator.test("321"); // true
 ```
 
-#### `includes: string`
-Checks the string includes a specific number or string.
+#### `includes: number | string`
+Checks the string includes a specific number or string. If passing number, it will be converted to string.
 
 ```ts
 const validator = marubatsu().string({ includes: "am" });

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ const isValidWebsite = marubatsu()
   - [`validate(value: any)`](#validatevalue-any)
 - [Operators](#operators)
   - [`string(rules: { [ruleName]: any } = {})`](#stringrules--rulename-any---)
+    - [`value: number | string`](#value-number--string)
     - [`length: number`](#length-number)
     - [`length: [number, number]`](#length-number-number)
     - [`maximumLength: number`](#maximumlength-number)
@@ -229,8 +230,18 @@ validator.test("ok"); // true
 validator.test(123);  // false
 ```
 
+#### `value: number | string`
+Checks the string is equal to a specific number or string. If passing number, it will be converted to string.
+
+```ts
+const validator = marubatsu().string({ value: 123 });
+
+validator.test("123");  // true
+validator.test("1234"); // false
+```
+
 #### `length: number`
-Checks the string length is equal to specific length.
+Checks the string length is equal to a specific length.
 
 ```ts
 const validator = marubatsu().string({ length: 3 });

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ const isValidWebsite = marubatsu()
   - [`test(value: any)`](#testvalue-any)
   - [`validate(value: any)`](#validatevalue-any)
 - [Operators](#operators)
+  - [`nullary()`](#nullary)
+  - [`empty()`](#empty)
+  - [`blank()`](#blank)
+  - [`present()`](#present)
   - [`string(rules: { [ruleName]: any } = {})`](#stringrules--rulename-any---)
     - [`value: number | string`](#value-number--string)
     - [`length: number`](#length-number)
@@ -219,6 +223,62 @@ marubatsu().string({ length: [4, 20], startsWith: "@" }).validate("abc");
 
 ## Operators
 **Operators** is validation to check the value conforms specific rules.
+
+### `nullary()`
+Checks the value is `null` or `undefined` .
+
+```ts
+const validator = marubatsu().nullary();
+
+validator.test(null); // true
+validator.test(undefined); // true
+validator.test(-1); // false
+validator.test(0); // false
+validator.test(""); // false
+validator.test(" "); // false
+validator.test(false); // false
+validator.test([]); // false
+validator.test({}); // false
+```
+
+### `empty()`
+Checks the value is an empty string, an empty array, or an empty object (pure object/hash/dictionary).
+
+```ts
+const validator = marubatsu().nullary();
+
+validator.test(null); // false
+validator.test(undefined); // false
+validator.test(-1); // false
+validator.test(0); // false
+validator.test(""); // true
+validator.test(" "); // false
+validator.test(false); // false
+validator.test([]); // true
+validator.test({}); // true
+```
+
+### `blank()`
+Checks the value is `null` , `undefined` , an empty string, a string including only spaces, an empty array, an empty object
+(pure object/hash/dictionary), or `false` .
+
+```ts
+const validator = marubatsu().nullary();
+
+validator.test(null); // true
+validator.test(undefined); // true
+validator.test(-1); // false
+validator.test(0); // false
+validator.test(""); // true
+validator.test(" "); // true
+validator.test(false); // true
+validator.test([]); // true
+validator.test({}); // true
+```
+
+### `present()`
+Checks the value is NOT `null` , `undefined` , an empty string, a string including only spaces, an empty array, an empty object
+(pure object/hash/dictionary), or `false` . This operator is equal to `not.blank()`
 
 ### `string(rules: { [ruleName]: any } = {})`
 Checks the value is string type and conforms rules related to string.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const isValidWebsite = marubatsu()
     - [`minimumLength: number`](#minimumlength-number)
     - [`startsWith: number | string`](#startswith-number--string)
     - [`endsWith: number | string`](#endswith-number--string)
-    - [`includes: number | string`](#includes-number--string)
+    - [`includes: string`](#includes-string)
     - [`pattern: RegExp`](#pattern-regexp)
 - [Options](#options)
     - [`checkAll: boolean = false`](#checkall-boolean--false)
@@ -252,7 +252,7 @@ validator.test("1234"); // false
 ```
 
 #### `length: [number, number]`
-Checks the string length is between specific length range. The first number is minimum length and second number is maximum
+Checks the string length is between specific length range. The first number is minimum length and the second number is maximum
 length.
 
 ```ts
@@ -288,7 +288,7 @@ validator.test("1234"); // true
 
 
 #### `startsWith: number | string`
-Checks the string is starting with a specific number or string. If passing number, it will be convert to string value.
+Checks the string is starting with a specific number or string. If passing number, it will be converted to string value.
 
 ```ts
 const validator = marubatsu().string({ startsWith: 1 });
@@ -299,7 +299,7 @@ validator.test("321"); // false
 ```
 
 #### `endsWith: number | string`
-Checks the string is ending with a specific number or string. If passing number, it will be convert to string value.
+Checks the string is ending with a specific number or string. If passing number, it will be converted to string value.
 
 ```ts
 const validator = marubatsu().string({ endsWith: 1 });
@@ -309,8 +309,8 @@ validator.test("231"); // true
 validator.test("321"); // true
 ```
 
-#### `includes: number | string`
-Checks the string includes a specific number or string. If passing number, it will be convert to string value.
+#### `includes: string`
+Checks the string includes a specific number or string.
 
 ```ts
 const validator = marubatsu().string({ includes: "am" });

--- a/src/checkers/alphanumeric-checker.test.ts
+++ b/src/checkers/alphanumeric-checker.test.ts
@@ -1,0 +1,102 @@
+// =============================================================================================================================
+// SRC - CHECKERS - ALPHANUMERIC CHECKER TEST
+// =============================================================================================================================
+/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+import { expect } from "chai";
+import { isAlphanumeric } from "./alphanumeric-checker";
+
+describe("[ Alphanumeric Checker ]", function() {
+  context("when a value is undefined,", function() {
+    it("should return false", function() {
+      expect(isAlphanumeric(undefined)).to.be.false;
+    });
+  });
+
+  context("when a value is null,", function() {
+    it("should return false", function() {
+      expect(isAlphanumeric(null)).to.be.false;
+    });
+  });
+
+  context("when a value is number,", function() {
+    context("zero,", function() {
+      it("should return true", function() {
+        expect(isAlphanumeric(0)).to.be.true;
+      });
+    });
+
+    context("a positive integer,", function() {
+      it("should return true", function() {
+        expect(isAlphanumeric(1)).to.be.true;
+      });
+    });
+
+    context("a negative integer,", function() {
+      it("should return false", function() {
+        expect(isAlphanumeric(-1)).to.be.false;
+      });
+    });
+
+    context("a floating point number,", function() {
+      it("should return false", function() {
+        expect(isAlphanumeric(1.1)).to.be.false;
+        expect(isAlphanumeric(-1.1)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is string,", function() {
+    context("including only number and alphabets,", function() {
+      it("should return true", function() {
+        expect(isAlphanumeric("0")).to.be.true;
+        expect(isAlphanumeric("1")).to.be.true;
+        expect(isAlphanumeric("Abc")).to.be.true;
+        expect(isAlphanumeric("00Abc11")).to.be.true;
+      });
+    });
+
+    context("an empty string,", function() {
+      it("should return true", function() {
+        expect(isAlphanumeric("")).to.be.true;
+      });
+    });
+
+    context("including spaces and symbols,", function() {
+      it("should return false", function() {
+        expect(isAlphanumeric(" ")).to.be.false;
+        expect(isAlphanumeric("-")).to.be.false;
+        expect(isAlphanumeric("!")).to.be.false;
+        expect(isAlphanumeric("?")).to.be.false;
+        expect(isAlphanumeric("+")).to.be.false;
+        expect(isAlphanumeric("@")).to.be.false;
+        expect(isAlphanumeric("#")).to.be.false;
+        expect(isAlphanumeric("-1")).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is boolean,", function() {
+    it("should return false", function() {
+      expect(isAlphanumeric(true)).to.be.false;
+      expect(isAlphanumeric(false)).to.be.false;
+    });
+  });
+
+  context("when a value is array,", function() {
+    it("should return false", function() {
+      expect(isAlphanumeric([])).to.be.false;
+    });
+  });
+
+  context("when a value is object,", function() {
+    it("should return false", function() {
+      expect(isAlphanumeric({})).to.be.false;
+    });
+  });
+
+  context("when a value is function,", function() {
+    it("should return false", function() {
+      expect(isAlphanumeric(() => true)).to.be.false;
+    });
+  });
+});

--- a/src/checkers/alphanumeric-checker.test.ts
+++ b/src/checkers/alphanumeric-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - ALPHANUMERIC CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { isAlphanumeric } from "./alphanumeric-checker";
 

--- a/src/checkers/alphanumeric-checker.test.ts
+++ b/src/checkers/alphanumeric-checker.test.ts
@@ -88,7 +88,7 @@ describe("[ Alphanumeric Checker ]", function() {
     });
   });
 
-  context("when a value is object,", function() {
+  context("when a value is object (pure object/hash/dictionary),", function() {
     it("should return false", function() {
       expect(isAlphanumeric({})).to.be.false;
     });

--- a/src/checkers/alphanumeric-checker.ts
+++ b/src/checkers/alphanumeric-checker.ts
@@ -1,0 +1,21 @@
+// =============================================================================================================================
+// SRC - CHECKERS - ALPHANUMERIC CHECKER
+// =============================================================================================================================
+export const isAlphanumeric = (value: any) => {
+  let stringValue: string = "";
+
+  switch (typeof value) {
+    case "number":
+      stringValue = value.toString();
+
+      break;
+    case "string":
+      stringValue = value;
+
+      break;
+    default:
+      return false;
+  }
+
+  return /^[0-9a-zA-z]*$/.test(stringValue);
+};

--- a/src/checkers/blank-checker.test.ts
+++ b/src/checkers/blank-checker.test.ts
@@ -6,19 +6,19 @@ import { expect } from "chai";
 import { isBlank } from "./blank-checker";
 
 describe("[ Blank Checker ]", function() {
-  context("when calling with undefined,", function() {
+  context("when a value is undefined,", function() {
     it("should return true", function() {
       expect(isBlank(undefined)).to.be.true;
     });
   });
 
-  context("when calling with null,", function() {
+  context("when a value is null,", function() {
     it("should return true", function() {
       expect(isBlank(null)).to.be.true;
     });
   });
 
-  context("when calling with number,", function() {
+  context("when a value is number,", function() {
     context("zero,", function() {
       it("should return false", function() {
         expect(isBlank(0)).to.be.false;
@@ -38,7 +38,7 @@ describe("[ Blank Checker ]", function() {
     });
   });
 
-  context("when calling with string,", function() {
+  context("when a value is string,", function() {
     context("an empty string,", function() {
       it("should return true", function() {
         expect(isBlank("")).to.be.true;
@@ -60,7 +60,7 @@ describe("[ Blank Checker ]", function() {
     });
   });
 
-  context("when calling with boolean,", function() {
+  context("when a value is boolean,", function() {
     context("true,", function() {
       it("should return false", function() {
         expect(isBlank(true)).to.be.false;
@@ -74,7 +74,7 @@ describe("[ Blank Checker ]", function() {
     });
   });
 
-  context("when calling with array,", function() {
+  context("when a value is array,", function() {
     context("an empty array,", function() {
       it("should return true", function() {
         expect(isBlank([])).to.be.true;
@@ -100,7 +100,7 @@ describe("[ Blank Checker ]", function() {
     });
   });
 
-  context("when calling with object,", function() {
+  context("when a value is object,", function() {
     context("an empty object,", function() {
       it("should return true", function() {
         expect(isBlank({})).to.be.true;
@@ -120,7 +120,7 @@ describe("[ Blank Checker ]", function() {
     });
   });
 
-  context("when calling with function,", function() {
+  context("when a value is function,", function() {
     it("should return false", function() {
       expect(isBlank(() => true)).to.be.false;
     });

--- a/src/checkers/blank-checker.test.ts
+++ b/src/checkers/blank-checker.test.ts
@@ -4,7 +4,6 @@
 /* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
 import { expect } from "chai";
 import { isBlank } from "./blank-checker";
-import { isEmpty } from "./empty-checker";
 
 describe("[ Blank Checker ]", function() {
   context("when calling with undefined,", function() {
@@ -123,7 +122,7 @@ describe("[ Blank Checker ]", function() {
 
   context("when calling with function,", function() {
     it("should return false", function() {
-      expect(isEmpty(() => true)).to.be.false;
+      expect(isBlank(() => true)).to.be.false;
     });
   });
 });

--- a/src/checkers/blank-checker.test.ts
+++ b/src/checkers/blank-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - BLANK CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { isBlank } from "./blank-checker";
 

--- a/src/checkers/camel-case-checker.test.ts
+++ b/src/checkers/camel-case-checker.test.ts
@@ -1,0 +1,256 @@
+// =============================================================================================================================
+// SRC - CHECKERS - CAMEL CASE CHECKER TEST
+// =============================================================================================================================
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
+import { expect } from "chai";
+import { isCamelCase } from "./camel-case-checker";
+
+describe("[ Camel Case Checker ]", function() {
+  context("when a value is undefined,", function() {
+    it("should return false", function() {
+      expect(isCamelCase(undefined, false)).to.be.false;
+      expect(isCamelCase(undefined, true)).to.be.false;
+    });
+  });
+
+  context("when a value is null,", function() {
+    it("should return false", function() {
+      expect(isCamelCase(null, false)).to.be.false;
+      expect(isCamelCase(null, true)).to.be.false;
+    });
+  });
+
+  context("when a value is number,", function() {
+    context("zero,", function() {
+      it("should return true", function() {
+        expect(isCamelCase(0, false)).to.be.true;
+        expect(isCamelCase(0, true)).to.be.true;
+      });
+    });
+
+    context("a positive number,", function() {
+      it("should return true", function() {
+        expect(isCamelCase(1, false)).to.be.true;
+        expect(isCamelCase(1, true)).to.be.true;
+      });
+    });
+
+    context("a negative number,", function() {
+      it("should return false", function() {
+        expect(isCamelCase(-1, false)).to.be.false;
+        expect(isCamelCase(-1, true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is string,", function() {
+    context("an empty string,", function() {
+      it("should return true", function() {
+        expect(isCamelCase("", false)).to.be.true;
+        expect(isCamelCase("", true)).to.be.true;
+      });
+    });
+
+    context("a lower camel case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return true", function() {
+          expect(isCamelCase("0", false)).to.be.true;
+          expect(isCamelCase("short", false)).to.be.true;
+          expect(isCamelCase("lowerCamelCase", false)).to.be.true;
+          expect(isCamelCase("lowerCCamel", false)).to.be.true;
+          expect(isCamelCase("000LowerCamelCase", false)).to.be.true;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return false", function() {
+          expect(isCamelCase("0", true)).to.be.true;
+          expect(isCamelCase("short", true)).to.be.false;
+          expect(isCamelCase("lowerCamelCase", true)).to.be.false;
+          expect(isCamelCase("lowerCCamel", true)).to.be.false;
+          expect(isCamelCase("000LowerCamelCase", true)).to.be.true;
+        });
+      });
+    });
+
+    context("an upper camel case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return false", function() {
+          expect(isCamelCase("0", false)).to.be.true;
+          expect(isCamelCase("Short", false)).to.be.false;
+          expect(isCamelCase("UpperCamelCase", false)).to.be.false;
+          expect(isCamelCase("UpperCCamel", false)).to.be.false;
+          expect(isCamelCase("000UpperCamelCase", false)).to.be.true;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return true", function() {
+          expect(isCamelCase("0", true)).to.be.true;
+          expect(isCamelCase("Short", true)).to.be.true;
+          expect(isCamelCase("UpperCamelCase", true)).to.be.true;
+          expect(isCamelCase("UpperCCamel", true)).to.be.true;
+          expect(isCamelCase("000UpperCamelCase", true)).to.be.true;
+        });
+      });
+    });
+
+    context("a lower snake case,", function() {
+      it("should return false", function() {
+        expect(isCamelCase("0_0", false)).to.be.false;
+        expect(isCamelCase("lower_snake_case", false)).to.be.false;
+        expect(isCamelCase("_lower_snake_case", false)).to.be.false;
+        expect(isCamelCase("lower_snake_case_", false)).to.be.false;
+        expect(isCamelCase("lower__snake", false)).to.be.false;
+        expect(isCamelCase("0_lower_snake_case", false)).to.be.false;
+        expect(isCamelCase("0_0", true)).to.be.false;
+        expect(isCamelCase("lower_snake_case", true)).to.be.false;
+        expect(isCamelCase("_lower_snake_case", true)).to.be.false;
+        expect(isCamelCase("lower_snake_case_", true)).to.be.false;
+        expect(isCamelCase("lower__snake", true)).to.be.false;
+        expect(isCamelCase("0_lower_snake_case", true)).to.be.false;
+      });
+    });
+
+    context("an upper snake case,", function() {
+      it("should return false", function() {
+        expect(isCamelCase("Upper_Snake_Case", false)).to.be.false;
+        expect(isCamelCase("_Upper_Snake_Case", false)).to.be.false;
+        expect(isCamelCase("Upper_Snake_Case_", false)).to.be.false;
+        expect(isCamelCase("Upper__Snake", false)).to.be.false;
+        expect(isCamelCase("0_Upper_Snake_Case", false)).to.be.false;
+        expect(isCamelCase("Upper_Snake_Case", true)).to.be.false;
+        expect(isCamelCase("_Upper_Snake_Case", true)).to.be.false;
+        expect(isCamelCase("Upper_Snake_Case_", true)).to.be.false;
+        expect(isCamelCase("Upper__Snake", true)).to.be.false;
+        expect(isCamelCase("0_Upper_Snake_Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower kebab case,", function() {
+      it("should return false", function() {
+        expect(isCamelCase("0-0", false)).to.be.false;
+        expect(isCamelCase("lower-kebab-case", false)).to.be.false;
+        expect(isCamelCase("-lower-kebab-case", false)).to.be.false;
+        expect(isCamelCase("lower-kebab-case-", false)).to.be.false;
+        expect(isCamelCase("lower--kebab", false)).to.be.false;
+        expect(isCamelCase("0-lower-kebab-case", false)).to.be.false;
+        expect(isCamelCase("0-0", true)).to.be.false;
+        expect(isCamelCase("lower-kebab-case", true)).to.be.false;
+        expect(isCamelCase("-lower-kebab-case", true)).to.be.false;
+        expect(isCamelCase("lower-kebab-case-", true)).to.be.false;
+        expect(isCamelCase("lower--kebab", true)).to.be.false;
+        expect(isCamelCase("0-lower-kebab-case", true)).to.be.false;
+      });
+    });
+
+    context("an upper kebab case,", function() {
+      it("should return false", function() {
+        expect(isCamelCase("Upper-Kebab-Case", false)).to.be.false;
+        expect(isCamelCase("-Upper-Kebab-Case", false)).to.be.false;
+        expect(isCamelCase("Upper-Kebab-Case-", false)).to.be.false;
+        expect(isCamelCase("Upper--Kebab", false)).to.be.false;
+        expect(isCamelCase("0-Upper-Kebab-Case", false)).to.be.false;
+        expect(isCamelCase("Upper-Kebab-Case", true)).to.be.false;
+        expect(isCamelCase("-Upper-Kebab-Case", true)).to.be.false;
+        expect(isCamelCase("Upper-Kebab-Case-", true)).to.be.false;
+        expect(isCamelCase("Upper--Kebab", true)).to.be.false;
+        expect(isCamelCase("0-Upper-Kebab-Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower space case,", function() {
+      it("should return false", function() {
+        expect(isCamelCase("0 0", false)).to.be.false;
+        expect(isCamelCase("lower space case", false)).to.be.false;
+        expect(isCamelCase(" lower space case", false)).to.be.false;
+        expect(isCamelCase("lower space case ", false)).to.be.false;
+        expect(isCamelCase("lower  space", false)).to.be.false;
+        expect(isCamelCase("0 lower space case", false)).to.be.false;
+        expect(isCamelCase("0 0", true)).to.be.false;
+        expect(isCamelCase("lower space case", true)).to.be.false;
+        expect(isCamelCase(" lower space case", true)).to.be.false;
+        expect(isCamelCase("lower space case ", true)).to.be.false;
+        expect(isCamelCase("lower  space", true)).to.be.false;
+        expect(isCamelCase("0 lower space case", true)).to.be.false;
+      });
+    });
+
+    context("an upper space case,", function() {
+      it("should return false", function() {
+        expect(isCamelCase("Upper Space Case", false)).to.be.false;
+        expect(isCamelCase(" Upper Space Case", false)).to.be.false;
+        expect(isCamelCase("Upper Space Case ", false)).to.be.false;
+        expect(isCamelCase("Upper  Space", false)).to.be.false;
+        expect(isCamelCase("0 Upper Space Case", false)).to.be.false;
+        expect(isCamelCase("Upper Space Case", true)).to.be.false;
+        expect(isCamelCase(" Upper Space Case", true)).to.be.false;
+        expect(isCamelCase("Upper Space Case ", true)).to.be.false;
+        expect(isCamelCase("Upper  Space", true)).to.be.false;
+        expect(isCamelCase("0 Upper Space Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower dot case,", function() {
+      it("should return false", function() {
+        expect(isCamelCase("0.0", false)).to.be.false;
+        expect(isCamelCase("lower.dot.case", false)).to.be.false;
+        expect(isCamelCase(".lower.dot.case", false)).to.be.false;
+        expect(isCamelCase("lower.dot.case.", false)).to.be.false;
+        expect(isCamelCase("lower..dot", false)).to.be.false;
+        expect(isCamelCase("0.lower.dot.case", false)).to.be.false;
+        expect(isCamelCase("0.0", true)).to.be.false;
+        expect(isCamelCase("lower.dot.case", true)).to.be.false;
+        expect(isCamelCase(".lower.dot.case", true)).to.be.false;
+        expect(isCamelCase("lower.dot.case.", true)).to.be.false;
+        expect(isCamelCase("lower..dot", true)).to.be.false;
+        expect(isCamelCase("0.lower.dot.case", true)).to.be.false;
+      });
+    });
+
+    context("an upper dot case,", function() {
+      it("should return false", function() {
+        expect(isCamelCase("Upper.Dot.Case", false)).to.be.false;
+        expect(isCamelCase(".Upper.Dot.Case", false)).to.be.false;
+        expect(isCamelCase("Upper.Dot.Case.", false)).to.be.false;
+        expect(isCamelCase("Upper..Dot", false)).to.be.false;
+        expect(isCamelCase("0.Upper.Dot.Case", false)).to.be.false;
+        expect(isCamelCase("Upper.Dot.Case", true)).to.be.false;
+        expect(isCamelCase(".Upper.Dot.Case", true)).to.be.false;
+        expect(isCamelCase("Upper.Dot.Case.", true)).to.be.false;
+        expect(isCamelCase("Upper..Dot", true)).to.be.false;
+        expect(isCamelCase("0.Upper.Dot.Case", true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is boolean,", function() {
+    it("should return false", function() {
+      expect(isCamelCase(true, false)).to.be.false;
+      expect(isCamelCase(true, true)).to.be.false;
+      expect(isCamelCase(false, false)).to.be.false;
+      expect(isCamelCase(false, true)).to.be.false;
+    });
+  });
+
+  context("when a value is array,", function() {
+    it("should return false", function() {
+      expect(isCamelCase([], false)).to.be.false;
+      expect(isCamelCase([], true)).to.be.false;
+    });
+  });
+
+  context("when a value is object (pure object/hash/dictionary),", function() {
+    it("should return false", function() {
+      expect(isCamelCase({}, false)).to.be.false;
+      expect(isCamelCase({}, true)).to.be.false;
+    });
+  });
+
+  context("when a value is function,", function() {
+    it("should return false", function() {
+      expect(isCamelCase(() => true, false)).to.be.false;
+      expect(isCamelCase(() => true, true)).to.be.false;
+    });
+  });
+});

--- a/src/checkers/camel-case-checker.ts
+++ b/src/checkers/camel-case-checker.ts
@@ -1,0 +1,27 @@
+// =============================================================================================================================
+// SRC - CHECKERS - CAMEL CASE CHECKER
+// =============================================================================================================================
+export const isCamelCase = (value: any, isUpper: boolean) => {
+  let stringValue: string = "";
+
+  switch (typeof value) {
+    case "number":
+      stringValue = value.toString();
+
+      break;
+    case "string":
+      if (value.length === 0) return true;
+      stringValue = value;
+
+      break;
+    default:
+      return false;
+  }
+
+  if (stringValue.length === 0) return true;
+
+  const prefixPattern = isUpper ? "[0-9A-Z][a-z]*" : "[0-9a-z]+";
+  const regExp = new RegExp(`^${prefixPattern}([0-9A-Z][a-z]*)*$`);
+
+  return regExp.test(stringValue);
+};

--- a/src/checkers/camel-case-checker.ts
+++ b/src/checkers/camel-case-checker.ts
@@ -18,8 +18,6 @@ export const isCamelCase = (value: any, isUpper: boolean) => {
       return false;
   }
 
-  if (stringValue.length === 0) return true;
-
   const prefixPattern = isUpper ? "[0-9A-Z][a-z]*" : "[0-9a-z]+";
   const regExp = new RegExp(`^${prefixPattern}([0-9A-Z][a-z]*)*$`);
 

--- a/src/checkers/dot-case-checker.test.ts
+++ b/src/checkers/dot-case-checker.test.ts
@@ -1,0 +1,254 @@
+// =============================================================================================================================
+// SRC - CHECKERS - DOT CASE CHECKER TEST
+// =============================================================================================================================
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
+import { expect } from "chai";
+import { isDotCase } from "./dot-case-checker";
+
+describe("[ Dot Case Checker ]", function() {
+  context("when a value is undefined,", function() {
+    it("should return false", function() {
+      expect(isDotCase(undefined, false)).to.be.false;
+      expect(isDotCase(undefined, true)).to.be.false;
+    });
+  });
+
+  context("when a value is null,", function() {
+    it("should return false", function() {
+      expect(isDotCase(null, false)).to.be.false;
+      expect(isDotCase(null, true)).to.be.false;
+    });
+  });
+
+  context("when a value is number,", function() {
+    context("zero,", function() {
+      it("should return true", function() {
+        expect(isDotCase(0, false)).to.be.true;
+        expect(isDotCase(0, true)).to.be.true;
+      });
+    });
+
+    context("a positive number,", function() {
+      it("should return true", function() {
+        expect(isDotCase(1, false)).to.be.true;
+        expect(isDotCase(1, true)).to.be.true;
+      });
+    });
+
+    context("a negative number,", function() {
+      it("should return false", function() {
+        expect(isDotCase(-1, false)).to.be.false;
+        expect(isDotCase(-1, true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is string,", function() {
+    context("an empty string,", function() {
+      it("should return true", function() {
+        expect(isDotCase("", false)).to.be.true;
+        expect(isDotCase("", true)).to.be.true;
+      });
+    });
+
+    context("a lower camel case,", function() {
+      it("should return false", function() {
+        expect(isDotCase("lowerCamelCase", false)).to.be.false;
+        expect(isDotCase("lowerCCamel", false)).to.be.false;
+        expect(isDotCase("000LowerCamelCase", false)).to.be.false;
+        expect(isDotCase("lowerCamelCase", true)).to.be.false;
+        expect(isDotCase("lowerCCamel", true)).to.be.false;
+        expect(isDotCase("000LowerCamelCase", true)).to.be.false;
+      });
+    });
+
+    context("an upper camel case,", function() {
+      it("should return false", function() {
+        expect(isDotCase("UpperCamelCase", false)).to.be.false;
+        expect(isDotCase("UpperCCamel", false)).to.be.false;
+        expect(isDotCase("000UpperCamelCase", false)).to.be.false;
+        expect(isDotCase("UpperCamelCase", true)).to.be.false;
+        expect(isDotCase("UpperCCamel", true)).to.be.false;
+        expect(isDotCase("000UpperCamelCase", true)).to.be.false;
+      });
+    });
+
+    context("a lower snake case,", function() {
+      it("should return false", function() {
+        expect(isDotCase("0_0", false)).to.be.false;
+        expect(isDotCase("lower_snake_case", false)).to.be.false;
+        expect(isDotCase("_lower_snake_case", false)).to.be.false;
+        expect(isDotCase("lower_snake_case_", false)).to.be.false;
+        expect(isDotCase("lower__snake", false)).to.be.false;
+        expect(isDotCase("0_lower_snake_case", false)).to.be.false;
+        expect(isDotCase("0_0", true)).to.be.false;
+        expect(isDotCase("lower_snake_case", true)).to.be.false;
+        expect(isDotCase("_lower_snake_case", true)).to.be.false;
+        expect(isDotCase("lower_snake_case_", true)).to.be.false;
+        expect(isDotCase("lower__snake", true)).to.be.false;
+        expect(isDotCase("0_lower_snake_case", true)).to.be.false;
+      });
+    });
+
+    context("an upper snake case,", function() {
+      it("should return false", function() {
+        expect(isDotCase("Upper_Snake_Case", false)).to.be.false;
+        expect(isDotCase("_Upper_Snake_Case", false)).to.be.false;
+        expect(isDotCase("Upper_Snake_Case_", false)).to.be.false;
+        expect(isDotCase("Upper__Snake", false)).to.be.false;
+        expect(isDotCase("0_Upper_Snake_Case", false)).to.be.false;
+        expect(isDotCase("Upper_Snake_Case", true)).to.be.false;
+        expect(isDotCase("_Upper_Snake_Case", true)).to.be.false;
+        expect(isDotCase("Upper_Snake_Case_", true)).to.be.false;
+        expect(isDotCase("Upper__Snake", true)).to.be.false;
+        expect(isDotCase("0_Upper_Snake_Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower kebab case,", function() {
+      it("should return false", function() {
+        expect(isDotCase("0-0", false)).to.be.false;
+        expect(isDotCase("lower-kebab-case", false)).to.be.false;
+        expect(isDotCase("-lower-kebab-case", false)).to.be.false;
+        expect(isDotCase("lower-kebab-case-", false)).to.be.false;
+        expect(isDotCase("lower--kebab", false)).to.be.false;
+        expect(isDotCase("0-lower-kebab-case", false)).to.be.false;
+        expect(isDotCase("0-0", true)).to.be.false;
+        expect(isDotCase("lower-kebab-case", true)).to.be.false;
+        expect(isDotCase("-lower-kebab-case", true)).to.be.false;
+        expect(isDotCase("lower-kebab-case-", true)).to.be.false;
+        expect(isDotCase("lower--kebab", true)).to.be.false;
+        expect(isDotCase("0-lower-kebab-case", true)).to.be.false;
+      });
+    });
+
+    context("an upper kebab case,", function() {
+      it("should return false", function() {
+        expect(isDotCase("Upper-Kebab-Case", false)).to.be.false;
+        expect(isDotCase("-Upper-Kebab-Case", false)).to.be.false;
+        expect(isDotCase("Upper-Kebab-Case-", false)).to.be.false;
+        expect(isDotCase("Upper--Kebab", false)).to.be.false;
+        expect(isDotCase("0-Upper-Kebab-Case", false)).to.be.false;
+        expect(isDotCase("Upper-Kebab-Case", true)).to.be.false;
+        expect(isDotCase("-Upper-Kebab-Case", true)).to.be.false;
+        expect(isDotCase("Upper-Kebab-Case-", true)).to.be.false;
+        expect(isDotCase("Upper--Kebab", true)).to.be.false;
+        expect(isDotCase("0-Upper-Kebab-Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower space case,", function() {
+      it("should return false", function() {
+        expect(isDotCase("0 0", false)).to.be.false;
+        expect(isDotCase("lower space case", false)).to.be.false;
+        expect(isDotCase(" lower space case", false)).to.be.false;
+        expect(isDotCase("lower space case ", false)).to.be.false;
+        expect(isDotCase("lower  space", false)).to.be.false;
+        expect(isDotCase("0 lower space case", false)).to.be.false;
+        expect(isDotCase("0 0", true)).to.be.false;
+        expect(isDotCase("lower space case", true)).to.be.false;
+        expect(isDotCase(" lower space case", true)).to.be.false;
+        expect(isDotCase("lower space case ", true)).to.be.false;
+        expect(isDotCase("lower  space", true)).to.be.false;
+        expect(isDotCase("0 lower space case", true)).to.be.false;
+      });
+    });
+
+    context("an upper space case,", function() {
+      it("should return false", function() {
+        expect(isDotCase("Upper Space Case", false)).to.be.false;
+        expect(isDotCase(" Upper Space Case", false)).to.be.false;
+        expect(isDotCase("Upper Space Case ", false)).to.be.false;
+        expect(isDotCase("Upper  Space", false)).to.be.false;
+        expect(isDotCase("0 Upper Space Case", false)).to.be.false;
+        expect(isDotCase("Upper Space Case", true)).to.be.false;
+        expect(isDotCase(" Upper Space Case", true)).to.be.false;
+        expect(isDotCase("Upper Space Case ", true)).to.be.false;
+        expect(isDotCase("Upper  Space", true)).to.be.false;
+        expect(isDotCase("0 Upper Space Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower dot case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return true", function() {
+          expect(isDotCase("0", false)).to.be.true;
+          expect(isDotCase("0.0", false)).to.be.true;
+          expect(isDotCase("short", false)).to.be.true;
+          expect(isDotCase("lower.dot.case", false)).to.be.true;
+          expect(isDotCase(".lower.dot.case", false)).to.be.false;
+          expect(isDotCase("lower.dot.case.", false)).to.be.false;
+          expect(isDotCase("lower..dot", false)).to.be.false;
+          expect(isDotCase("0.lower.dot.case", false)).to.be.true;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return false", function() {
+          expect(isDotCase("0", true)).to.be.true;
+          expect(isDotCase("0.0", true)).to.be.true;
+          expect(isDotCase("short", true)).to.be.false;
+          expect(isDotCase("lower.dot.case", true)).to.be.false;
+          expect(isDotCase(".lower.dot.case", true)).to.be.false;
+          expect(isDotCase("lower.dot.case.", true)).to.be.false;
+          expect(isDotCase("lower..dot", true)).to.be.false;
+          expect(isDotCase("0.lower.dot.case", true)).to.be.false;
+        });
+      });
+    });
+
+    context("an upper dot case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return false", function() {
+          expect(isDotCase("Short", false)).to.be.false;
+          expect(isDotCase("Upper.Dot.Case", false)).to.be.false;
+          expect(isDotCase(".Upper.Dot.Case", false)).to.be.false;
+          expect(isDotCase("Upper.Dot.Case.", false)).to.be.false;
+          expect(isDotCase("Upper..Dot", false)).to.be.false;
+          expect(isDotCase("0.Upper.Dot.Case", false)).to.be.false;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return true", function() {
+          expect(isDotCase("Short", true)).to.be.true;
+          expect(isDotCase("Upper.Dot.Case", true)).to.be.true;
+          expect(isDotCase(".Upper.Dot.Case", true)).to.be.false;
+          expect(isDotCase("Upper.Dot.Case.", true)).to.be.false;
+          expect(isDotCase("Upper..Dot", true)).to.be.false;
+          expect(isDotCase("0.Upper.Dot.Case", true)).to.be.true;
+        });
+      });
+    });
+  });
+
+  context("when a value is boolean,", function() {
+    it("should return false", function() {
+      expect(isDotCase(true, false)).to.be.false;
+      expect(isDotCase(true, true)).to.be.false;
+      expect(isDotCase(false, false)).to.be.false;
+      expect(isDotCase(false, true)).to.be.false;
+    });
+  });
+
+  context("when a value is array,", function() {
+    it("should return false", function() {
+      expect(isDotCase([], false)).to.be.false;
+      expect(isDotCase([], true)).to.be.false;
+    });
+  });
+
+  context("when a value is object (pure object/hash/dictionary),", function() {
+    it("should return false", function() {
+      expect(isDotCase({}, false)).to.be.false;
+      expect(isDotCase({}, true)).to.be.false;
+    });
+  });
+
+  context("when a value is function,", function() {
+    it("should return false", function() {
+      expect(isDotCase(() => true, false)).to.be.false;
+      expect(isDotCase(() => true, true)).to.be.false;
+    });
+  });
+});

--- a/src/checkers/dot-case-checker.ts
+++ b/src/checkers/dot-case-checker.ts
@@ -1,0 +1,25 @@
+// =============================================================================================================================
+// SRC - CHECKERS - DOT CASE CHECKER
+// =============================================================================================================================
+export const isDotCase = (value: any, isUpper: boolean) => {
+  let stringValue: string = "";
+
+  switch (typeof value) {
+    case "number":
+      stringValue = value.toString();
+
+      break;
+    case "string":
+      if (value.length === 0) return true;
+      stringValue = value;
+
+      break;
+    default:
+      return false;
+  }
+
+  const wordingPattern = isUpper ? "[0-9A-Z][a-z]*" : "[0-9a-z]+";
+  const regExp = new RegExp(`^${wordingPattern}(\\.${wordingPattern})*$`);
+
+  return regExp.test(stringValue);
+};

--- a/src/checkers/empty-checker.test.ts
+++ b/src/checkers/empty-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - EMPTY CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { isEmpty } from "./empty-checker";
 

--- a/src/checkers/empty-checker.test.ts
+++ b/src/checkers/empty-checker.test.ts
@@ -6,19 +6,19 @@ import { expect } from "chai";
 import { isEmpty } from "./empty-checker";
 
 describe("[ Empty Checker ]", function() {
-  context("when calling with undefined,", function() {
+  context("when a value is undefined,", function() {
     it("should return false", function() {
       expect(isEmpty(undefined)).to.be.false;
     });
   });
 
-  context("when calling with null,", function() {
+  context("when a value is null,", function() {
     it("should return false", function() {
       expect(isEmpty(null)).to.be.false;
     });
   });
 
-  context("when calling with number,", function() {
+  context("when a value is number,", function() {
     context("zero,", function() {
       it("should return false", function() {
         expect(isEmpty(0)).to.be.false;
@@ -38,7 +38,7 @@ describe("[ Empty Checker ]", function() {
     });
   });
 
-  context("when calling with string,", function() {
+  context("when a value is string,", function() {
     context("an empty string,", function() {
       it("should return true", function() {
         expect(isEmpty("")).to.be.true;
@@ -60,7 +60,7 @@ describe("[ Empty Checker ]", function() {
     });
   });
 
-  context("when calling with boolean,", function() {
+  context("when a value is boolean,", function() {
     context("true,", function() {
       it("should return false", function() {
         expect(isEmpty(true)).to.be.false;
@@ -74,7 +74,7 @@ describe("[ Empty Checker ]", function() {
     });
   });
 
-  context("when calling with array,", function() {
+  context("when a value is array,", function() {
     context("an empty array,", function() {
       it("should return true", function() {
         expect(isEmpty([])).to.be.true;
@@ -100,7 +100,7 @@ describe("[ Empty Checker ]", function() {
     });
   });
 
-  context("when calling with object,", function() {
+  context("when a value is object,", function() {
     context("an empty object,", function() {
       it("should return true", function() {
         expect(isEmpty({})).to.be.true;
@@ -120,7 +120,7 @@ describe("[ Empty Checker ]", function() {
     });
   });
 
-  context("when calling with function,", function() {
+  context("when a value is function,", function() {
     it("should return false", function() {
       expect(isEmpty(() => true)).to.be.false;
     });

--- a/src/checkers/ends-with-checker.test.ts
+++ b/src/checkers/ends-with-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - ENDS WITH CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { endsWith } from "./ends-with-checker";
 

--- a/src/checkers/equal-length-checker.test.ts
+++ b/src/checkers/equal-length-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - EQUAL LENGTH CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { isEqualToLength } from "./equal-length-checker";
 

--- a/src/checkers/includes-checker.test.ts
+++ b/src/checkers/includes-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - INCLUDES CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { includes } from "./includes-checker";
 

--- a/src/checkers/index.ts
+++ b/src/checkers/index.ts
@@ -3,6 +3,7 @@
 // =============================================================================================================================
 export { isAlphanumeric } from "./alphanumeric-checker";
 export { isBlank } from "./blank-checker";
+export { isCamelCase } from "./camel-case-checker";
 export { isEmpty } from "./empty-checker";
 export { endsWith } from "./ends-with-checker";
 export { isEqualToLength } from "./equal-length-checker";

--- a/src/checkers/index.ts
+++ b/src/checkers/index.ts
@@ -12,6 +12,7 @@ export { isKebabCase } from "./kebab-case-checker";
 export { isNullary } from "./nullary-checker";
 export { isConformingRegExp } from "./regexp-checker";
 export { isSnakeCase } from "./snake-case-checker";
+export { isSpaceCase } from "./space-case-checker";
 export { startsWith } from "./starts-with-checker";
 export { isType } from "./type-checker";
 export { isWithinLengthRange } from "./within-length-range-checker";

--- a/src/checkers/index.ts
+++ b/src/checkers/index.ts
@@ -1,6 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - INDEX
 // =============================================================================================================================
+export { isAlphanumeric } from "./alphanumeric-checker";
 export { isBlank } from "./blank-checker";
 export { isEmpty } from "./empty-checker";
 export { endsWith } from "./ends-with-checker";

--- a/src/checkers/index.ts
+++ b/src/checkers/index.ts
@@ -4,6 +4,7 @@
 export { isAlphanumeric } from "./alphanumeric-checker";
 export { isBlank } from "./blank-checker";
 export { isCamelCase } from "./camel-case-checker";
+export { isDotCase } from "./dot-case-checker";
 export { isEmpty } from "./empty-checker";
 export { endsWith } from "./ends-with-checker";
 export { isEqualToLength } from "./equal-length-checker";

--- a/src/checkers/index.ts
+++ b/src/checkers/index.ts
@@ -8,6 +8,7 @@ export { isEmpty } from "./empty-checker";
 export { endsWith } from "./ends-with-checker";
 export { isEqualToLength } from "./equal-length-checker";
 export { includes } from "./includes-checker";
+export { isKebabCase } from "./kebab-case-checker";
 export { isNullary } from "./nullary-checker";
 export { isConformingRegExp } from "./regexp-checker";
 export { isSnakeCase } from "./snake-case-checker";

--- a/src/checkers/index.ts
+++ b/src/checkers/index.ts
@@ -10,6 +10,7 @@ export { isEqualToLength } from "./equal-length-checker";
 export { includes } from "./includes-checker";
 export { isNullary } from "./nullary-checker";
 export { isConformingRegExp } from "./regexp-checker";
+export { isSnakeCase } from "./snake-case-checker";
 export { startsWith } from "./starts-with-checker";
 export { isType } from "./type-checker";
 export { isWithinLengthRange } from "./within-length-range-checker";

--- a/src/checkers/kebab-case-checker.test.ts
+++ b/src/checkers/kebab-case-checker.test.ts
@@ -1,0 +1,254 @@
+// =============================================================================================================================
+// SRC - CHECKERS - KEBAB CASE CHECKER TEST
+// =============================================================================================================================
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
+import { expect } from "chai";
+import { isKebabCase } from "./kebab-case-checker";
+
+describe("[ Kebab Case Checker ]", function() {
+  context("when a value is undefined,", function() {
+    it("should return false", function() {
+      expect(isKebabCase(undefined, false)).to.be.false;
+      expect(isKebabCase(undefined, true)).to.be.false;
+    });
+  });
+
+  context("when a value is null,", function() {
+    it("should return false", function() {
+      expect(isKebabCase(null, false)).to.be.false;
+      expect(isKebabCase(null, true)).to.be.false;
+    });
+  });
+
+  context("when a value is number,", function() {
+    context("zero,", function() {
+      it("should return true", function() {
+        expect(isKebabCase(0, false)).to.be.true;
+        expect(isKebabCase(0, true)).to.be.true;
+      });
+    });
+
+    context("a positive number,", function() {
+      it("should return true", function() {
+        expect(isKebabCase(1, false)).to.be.true;
+        expect(isKebabCase(1, true)).to.be.true;
+      });
+    });
+
+    context("a negative number,", function() {
+      it("should return false", function() {
+        expect(isKebabCase(-1, false)).to.be.false;
+        expect(isKebabCase(-1, true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is string,", function() {
+    context("an empty string,", function() {
+      it("should return true", function() {
+        expect(isKebabCase("", false)).to.be.true;
+        expect(isKebabCase("", true)).to.be.true;
+      });
+    });
+
+    context("a lower camel case,", function() {
+      it("should return false", function() {
+        expect(isKebabCase("lowerCamelCase", false)).to.be.false;
+        expect(isKebabCase("lowerCCamel", false)).to.be.false;
+        expect(isKebabCase("000LowerCamelCase", false)).to.be.false;
+        expect(isKebabCase("lowerCamelCase", true)).to.be.false;
+        expect(isKebabCase("lowerCCamel", true)).to.be.false;
+        expect(isKebabCase("000LowerCamelCase", true)).to.be.false;
+      });
+    });
+
+    context("an upper camel case,", function() {
+      it("should return false", function() {
+        expect(isKebabCase("UpperCamelCase", false)).to.be.false;
+        expect(isKebabCase("UpperCCamel", false)).to.be.false;
+        expect(isKebabCase("000UpperCamelCase", false)).to.be.false;
+        expect(isKebabCase("UpperCamelCase", true)).to.be.false;
+        expect(isKebabCase("UpperCCamel", true)).to.be.false;
+        expect(isKebabCase("000UpperCamelCase", true)).to.be.false;
+      });
+    });
+
+    context("a lower snake case,", function() {
+      it("should return false", function() {
+        expect(isKebabCase("0_0", false)).to.be.false;
+        expect(isKebabCase("lower_snake_case", false)).to.be.false;
+        expect(isKebabCase("_lower_snake_case", false)).to.be.false;
+        expect(isKebabCase("lower_snake_case_", false)).to.be.false;
+        expect(isKebabCase("lower__snake", false)).to.be.false;
+        expect(isKebabCase("0_lower_snake_case", false)).to.be.false;
+        expect(isKebabCase("0_0", true)).to.be.false;
+        expect(isKebabCase("lower_snake_case", true)).to.be.false;
+        expect(isKebabCase("_lower_snake_case", true)).to.be.false;
+        expect(isKebabCase("lower_snake_case_", true)).to.be.false;
+        expect(isKebabCase("lower__snake", true)).to.be.false;
+        expect(isKebabCase("0_lower_snake_case", true)).to.be.false;
+      });
+    });
+
+    context("an upper snake case,", function() {
+      it("should return false", function() {
+        expect(isKebabCase("Upper_Snake_Case", false)).to.be.false;
+        expect(isKebabCase("_Upper_Snake_Case", false)).to.be.false;
+        expect(isKebabCase("Upper_Snake_Case_", false)).to.be.false;
+        expect(isKebabCase("Upper__Snake", false)).to.be.false;
+        expect(isKebabCase("0_Upper_Snake_Case", false)).to.be.false;
+        expect(isKebabCase("Upper_Snake_Case", true)).to.be.false;
+        expect(isKebabCase("_Upper_Snake_Case", true)).to.be.false;
+        expect(isKebabCase("Upper_Snake_Case_", true)).to.be.false;
+        expect(isKebabCase("Upper__Snake", true)).to.be.false;
+        expect(isKebabCase("0_Upper_Snake_Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower kebab case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return true", function() {
+          expect(isKebabCase("0", false)).to.be.true;
+          expect(isKebabCase("0-0", false)).to.be.true;
+          expect(isKebabCase("short", false)).to.be.true;
+          expect(isKebabCase("lower-kebab-case", false)).to.be.true;
+          expect(isKebabCase("-lower-kebab-case", false)).to.be.false;
+          expect(isKebabCase("lower-kebab-case-", false)).to.be.false;
+          expect(isKebabCase("lower--kebab", false)).to.be.false;
+          expect(isKebabCase("0-lower-kebab-case", false)).to.be.true;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return false", function() {
+          expect(isKebabCase("0", true)).to.be.true;
+          expect(isKebabCase("0-0", true)).to.be.true;
+          expect(isKebabCase("short", true)).to.be.false;
+          expect(isKebabCase("lower-kebab-case", true)).to.be.false;
+          expect(isKebabCase("-lower-kebab-case", true)).to.be.false;
+          expect(isKebabCase("lower-kebab-case-", true)).to.be.false;
+          expect(isKebabCase("lower--kebab", true)).to.be.false;
+          expect(isKebabCase("0-lower-kebab-case", true)).to.be.false;
+        });
+      });
+    });
+
+    context("an upper kebab case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return false", function() {
+          expect(isKebabCase("Short", false)).to.be.false;
+          expect(isKebabCase("Upper-Kebab-Case", false)).to.be.false;
+          expect(isKebabCase("-Upper-Kebab-Case", false)).to.be.false;
+          expect(isKebabCase("Upper-Kebab-Case-", false)).to.be.false;
+          expect(isKebabCase("Upper--Kebab", false)).to.be.false;
+          expect(isKebabCase("0-Upper-Kebab-Case", false)).to.be.false;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return true", function() {
+          expect(isKebabCase("Short", true)).to.be.true;
+          expect(isKebabCase("Upper-Kebab-Case", true)).to.be.true;
+          expect(isKebabCase("-Upper-Kebab-Case", true)).to.be.false;
+          expect(isKebabCase("Upper-Kebab-Case-", true)).to.be.false;
+          expect(isKebabCase("Upper--Kebab", true)).to.be.false;
+          expect(isKebabCase("0-Upper-Kebab-Case", true)).to.be.true;
+        });
+      });
+    });
+
+    context("a lower space case,", function() {
+      it("should return false", function() {
+        expect(isKebabCase("0 0", false)).to.be.false;
+        expect(isKebabCase("lower space case", false)).to.be.false;
+        expect(isKebabCase(" lower space case", false)).to.be.false;
+        expect(isKebabCase("lower space case ", false)).to.be.false;
+        expect(isKebabCase("lower  space", false)).to.be.false;
+        expect(isKebabCase("0 lower space case", false)).to.be.false;
+        expect(isKebabCase("0 0", true)).to.be.false;
+        expect(isKebabCase("lower space case", true)).to.be.false;
+        expect(isKebabCase(" lower space case", true)).to.be.false;
+        expect(isKebabCase("lower space case ", true)).to.be.false;
+        expect(isKebabCase("lower  space", true)).to.be.false;
+        expect(isKebabCase("0 lower space case", true)).to.be.false;
+      });
+    });
+
+    context("an upper space case,", function() {
+      it("should return false", function() {
+        expect(isKebabCase("Upper Space Case", false)).to.be.false;
+        expect(isKebabCase(" Upper Space Case", false)).to.be.false;
+        expect(isKebabCase("Upper Space Case ", false)).to.be.false;
+        expect(isKebabCase("Upper  Space", false)).to.be.false;
+        expect(isKebabCase("0 Upper Space Case", false)).to.be.false;
+        expect(isKebabCase("Upper Space Case", true)).to.be.false;
+        expect(isKebabCase(" Upper Space Case", true)).to.be.false;
+        expect(isKebabCase("Upper Space Case ", true)).to.be.false;
+        expect(isKebabCase("Upper  Space", true)).to.be.false;
+        expect(isKebabCase("0 Upper Space Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower dot case,", function() {
+      it("should return false", function() {
+        expect(isKebabCase("0.0", false)).to.be.false;
+        expect(isKebabCase("lower.dot.case", false)).to.be.false;
+        expect(isKebabCase(".lower.dot.case", false)).to.be.false;
+        expect(isKebabCase("lower.dot.case.", false)).to.be.false;
+        expect(isKebabCase("lower..dot", false)).to.be.false;
+        expect(isKebabCase("0.lower.dot.case", false)).to.be.false;
+        expect(isKebabCase("0.0", true)).to.be.false;
+        expect(isKebabCase("lower.dot.case", true)).to.be.false;
+        expect(isKebabCase(".lower.dot.case", true)).to.be.false;
+        expect(isKebabCase("lower.dot.case.", true)).to.be.false;
+        expect(isKebabCase("lower..dot", true)).to.be.false;
+        expect(isKebabCase("0.lower.dot.case", true)).to.be.false;
+      });
+    });
+
+    context("an upper dot case,", function() {
+      it("should return false", function() {
+        expect(isKebabCase("Upper.Dot.Case", false)).to.be.false;
+        expect(isKebabCase(".Upper.Dot.Case", false)).to.be.false;
+        expect(isKebabCase("Upper.Dot.Case.", false)).to.be.false;
+        expect(isKebabCase("Upper..Dot", false)).to.be.false;
+        expect(isKebabCase("0.Upper.Dot.Case", false)).to.be.false;
+        expect(isKebabCase("Upper.Dot.Case", true)).to.be.false;
+        expect(isKebabCase(".Upper.Dot.Case", true)).to.be.false;
+        expect(isKebabCase("Upper.Dot.Case.", true)).to.be.false;
+        expect(isKebabCase("Upper..Dot", true)).to.be.false;
+        expect(isKebabCase("0.Upper.Dot.Case", true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is boolean,", function() {
+    it("should return false", function() {
+      expect(isKebabCase(true, false)).to.be.false;
+      expect(isKebabCase(true, true)).to.be.false;
+      expect(isKebabCase(false, false)).to.be.false;
+      expect(isKebabCase(false, true)).to.be.false;
+    });
+  });
+
+  context("when a value is array,", function() {
+    it("should return false", function() {
+      expect(isKebabCase([], false)).to.be.false;
+      expect(isKebabCase([], true)).to.be.false;
+    });
+  });
+
+  context("when a value is object (pure object/hash/dictionary),", function() {
+    it("should return false", function() {
+      expect(isKebabCase({}, false)).to.be.false;
+      expect(isKebabCase({}, true)).to.be.false;
+    });
+  });
+
+  context("when a value is function,", function() {
+    it("should return false", function() {
+      expect(isKebabCase(() => true, false)).to.be.false;
+      expect(isKebabCase(() => true, true)).to.be.false;
+    });
+  });
+});

--- a/src/checkers/kebab-case-checker.ts
+++ b/src/checkers/kebab-case-checker.ts
@@ -1,0 +1,25 @@
+// =============================================================================================================================
+// SRC - CHECKERS - KEBAB CASE CHECKER
+// =============================================================================================================================
+export const isKebabCase = (value: any, isUpper: boolean) => {
+  let stringValue: string = "";
+
+  switch (typeof value) {
+    case "number":
+      stringValue = value.toString();
+
+      break;
+    case "string":
+      if (value.length === 0) return true;
+      stringValue = value;
+
+      break;
+    default:
+      return false;
+  }
+
+  const wordingPattern = isUpper ? "[0-9A-Z][a-z]*" : "[0-9a-z]+";
+  const regExp = new RegExp(`^${wordingPattern}(\-${wordingPattern})*$`);
+
+  return regExp.test(stringValue);
+};

--- a/src/checkers/nullary-checker.test.ts
+++ b/src/checkers/nullary-checker.test.ts
@@ -6,19 +6,19 @@ import { expect } from "chai";
 import { isNullary } from "./nullary-checker";
 
 describe("[ Nullary Checker ]", function() {
-  context("when calling with undefined,", function() {
+  context("when a value is undefined,", function() {
     it("should return true", function() {
       expect(isNullary(undefined)).to.be.true;
     });
   });
 
-  context("when calling with null,", function() {
+  context("when a value is null,", function() {
     it("should return true", function() {
       expect(isNullary(null)).to.be.true;
     });
   });
 
-  context("when calling with number,", function() {
+  context("when a value is number,", function() {
     context("zero,", function() {
       it("should return false", function() {
         expect(isNullary(0)).to.be.false;
@@ -38,7 +38,7 @@ describe("[ Nullary Checker ]", function() {
     });
   });
 
-  context("when calling with string,", function() {
+  context("when a value is string,", function() {
     context("an empty string,", function() {
       it("should return false", function() {
         expect(isNullary("")).to.be.false;
@@ -60,7 +60,7 @@ describe("[ Nullary Checker ]", function() {
     });
   });
 
-  context("when calling with boolean,", function() {
+  context("when a value is boolean,", function() {
     context("true,", function() {
       it("should return false", function() {
         expect(isNullary(true)).to.be.false;
@@ -74,7 +74,7 @@ describe("[ Nullary Checker ]", function() {
     });
   });
 
-  context("when calling with array,", function() {
+  context("when a value is array,", function() {
     context("an empty array,", function() {
       it("should return false", function() {
         expect(isNullary([])).to.be.false;
@@ -100,7 +100,7 @@ describe("[ Nullary Checker ]", function() {
     });
   });
 
-  context("when calling with object,", function() {
+  context("when a value is object,", function() {
     context("an empty object,", function() {
       it("should return false", function() {
         expect(isNullary({})).to.be.false;
@@ -120,7 +120,7 @@ describe("[ Nullary Checker ]", function() {
     });
   });
 
-  context("when calling with function,", function() {
+  context("when a value is function,", function() {
     it("should return false", function() {
       expect(isNullary(() => true)).to.be.false;
     });

--- a/src/checkers/nullary-checker.test.ts
+++ b/src/checkers/nullary-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - NULLARY CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { isNullary } from "./nullary-checker";
 

--- a/src/checkers/regexp-checker.test.ts
+++ b/src/checkers/regexp-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - REGEXP CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { isConformingRegExp } from "./regexp-checker";
 

--- a/src/checkers/regexp-checker.ts
+++ b/src/checkers/regexp-checker.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - REGEXP CHECKER
 // =============================================================================================================================
-export const isConformingRegExp = (value: any, regexp: RegExp) => {
+export const isConformingRegExp = (value: any, regExp: RegExp) => {
   if (value == undefined) return false;
 
   let stringValue: string = "";
@@ -19,5 +19,5 @@ export const isConformingRegExp = (value: any, regexp: RegExp) => {
       return false;
   }
 
-  return regexp.test(stringValue);
+  return regExp.test(stringValue);
 };

--- a/src/checkers/shared/length-getter.test.ts
+++ b/src/checkers/shared/length-getter.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - SHARED - LENGTH GETTER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { getLength } from "./length-getter";
 

--- a/src/checkers/snake-case-checker.test.ts
+++ b/src/checkers/snake-case-checker.test.ts
@@ -1,0 +1,250 @@
+// =============================================================================================================================
+// SRC - CHECKERS - SNAKE CASE CHECKER TEST
+// =============================================================================================================================
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
+import { expect } from "chai";
+import { isSnakeCase } from "./snake-case-checker";
+
+describe("[ Snake Case Checker ]", function() {
+  context("when a value is undefined,", function() {
+    it("should return false", function() {
+      expect(isSnakeCase(undefined, false)).to.be.false;
+      expect(isSnakeCase(undefined, true)).to.be.false;
+    });
+  });
+
+  context("when a value is null,", function() {
+    it("should return false", function() {
+      expect(isSnakeCase(null, false)).to.be.false;
+      expect(isSnakeCase(null, true)).to.be.false;
+    });
+  });
+
+  context("when a value is number,", function() {
+    context("zero,", function() {
+      it("should return true", function() {
+        expect(isSnakeCase(0, false)).to.be.true;
+        expect(isSnakeCase(0, true)).to.be.true;
+      });
+    });
+
+    context("a positive number,", function() {
+      it("should return true", function() {
+        expect(isSnakeCase(1, false)).to.be.true;
+        expect(isSnakeCase(1, true)).to.be.true;
+      });
+    });
+
+    context("a negative number,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase(-1, false)).to.be.false;
+        expect(isSnakeCase(-1, true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is string,", function() {
+    context("an empty string,", function() {
+      it("should return true", function() {
+        expect(isSnakeCase("", false)).to.be.true;
+        expect(isSnakeCase("", true)).to.be.true;
+      });
+    });
+
+    context("a lower camel case,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase("lowerCamelCase", false)).to.be.false;
+        expect(isSnakeCase("lowerCCamel", false)).to.be.false;
+        expect(isSnakeCase("000LowerCamelCase", false)).to.be.false;
+        expect(isSnakeCase("lowerCamelCase", true)).to.be.false;
+        expect(isSnakeCase("lowerCCamel", true)).to.be.false;
+        expect(isSnakeCase("000LowerCamelCase", true)).to.be.false;
+      });
+    });
+
+    context("an upper camel case,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase("UpperCamelCase", false)).to.be.false;
+        expect(isSnakeCase("UpperCCamel", false)).to.be.false;
+        expect(isSnakeCase("000UpperCamelCase", false)).to.be.false;
+        expect(isSnakeCase("UpperCamelCase", true)).to.be.false;
+        expect(isSnakeCase("UpperCCamel", true)).to.be.false;
+        expect(isSnakeCase("000UpperCamelCase", true)).to.be.false;
+      });
+    });
+
+    context("a lower snake case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return true", function() {
+          expect(isSnakeCase("0", false)).to.be.true;
+          expect(isSnakeCase("0_0", false)).to.be.true;
+          expect(isSnakeCase("lower_snake_case", false)).to.be.true;
+          expect(isSnakeCase("_lower_snake_case", false)).to.be.false;
+          expect(isSnakeCase("lower_snake_case_", false)).to.be.false;
+          expect(isSnakeCase("lower__snake", false)).to.be.false;
+          expect(isSnakeCase("0_lower_snake_case", false)).to.be.true;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return false", function() {
+          expect(isSnakeCase("0", true)).to.be.true;
+          expect(isSnakeCase("0_0", true)).to.be.true;
+          expect(isSnakeCase("lower_snake_case", true)).to.be.false;
+          expect(isSnakeCase("_lower_snake_case", true)).to.be.false;
+          expect(isSnakeCase("lower_snake_case_", true)).to.be.false;
+          expect(isSnakeCase("lower__snake", true)).to.be.false;
+          expect(isSnakeCase("0_lower_snake_case", true)).to.be.false;
+        });
+      });
+    });
+
+    context("an upper snake case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return false", function() {
+          expect(isSnakeCase("Upper_Snake_Case", false)).to.be.false;
+          expect(isSnakeCase("_Upper_Snake_Case", false)).to.be.false;
+          expect(isSnakeCase("Upper_Snake_Case_", false)).to.be.false;
+          expect(isSnakeCase("Upper__Snake", false)).to.be.false;
+          expect(isSnakeCase("0_Upper_Snake_Case", false)).to.be.false;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return true", function() {
+          expect(isSnakeCase("Upper_Snake_Case", true)).to.be.true;
+          expect(isSnakeCase("_Upper_Snake_Case", true)).to.be.false;
+          expect(isSnakeCase("Upper_Snake_Case_", true)).to.be.false;
+          expect(isSnakeCase("Upper__Snake", true)).to.be.false;
+          expect(isSnakeCase("0_Upper_Snake_Case", true)).to.be.true;
+        });
+      });
+    });
+
+    context("a lower kebab case,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase("0-0", false)).to.be.false;
+        expect(isSnakeCase("lower-kebab-case", false)).to.be.false;
+        expect(isSnakeCase("-lower-kebab-case", false)).to.be.false;
+        expect(isSnakeCase("lower-kebab-case-", false)).to.be.false;
+        expect(isSnakeCase("lower--kebab", false)).to.be.false;
+        expect(isSnakeCase("0-lower-kebab-case", false)).to.be.false;
+        expect(isSnakeCase("0-0", true)).to.be.false;
+        expect(isSnakeCase("lower-kebab-case", true)).to.be.false;
+        expect(isSnakeCase("-lower-kebab-case", true)).to.be.false;
+        expect(isSnakeCase("lower-kebab-case-", true)).to.be.false;
+        expect(isSnakeCase("lower--kebab", true)).to.be.false;
+        expect(isSnakeCase("0-lower-kebab-case", true)).to.be.false;
+      });
+    });
+
+    context("an upper kebab case,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase("Upper-Kebab-Case", false)).to.be.false;
+        expect(isSnakeCase("-Upper-Kebab-Case", false)).to.be.false;
+        expect(isSnakeCase("Upper-Kebab-Case-", false)).to.be.false;
+        expect(isSnakeCase("Upper--Kebab", false)).to.be.false;
+        expect(isSnakeCase("0-Upper-Kebab-Case", false)).to.be.false;
+        expect(isSnakeCase("Upper-Kebab-Case", true)).to.be.false;
+        expect(isSnakeCase("-Upper-Kebab-Case", true)).to.be.false;
+        expect(isSnakeCase("Upper-Kebab-Case-", true)).to.be.false;
+        expect(isSnakeCase("Upper--Kebab", true)).to.be.false;
+        expect(isSnakeCase("0-Upper-Kebab-Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower space case,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase("0 0", false)).to.be.false;
+        expect(isSnakeCase("lower space case", false)).to.be.false;
+        expect(isSnakeCase(" lower space case", false)).to.be.false;
+        expect(isSnakeCase("lower space case ", false)).to.be.false;
+        expect(isSnakeCase("lower  space", false)).to.be.false;
+        expect(isSnakeCase("0 lower space case", false)).to.be.false;
+        expect(isSnakeCase("0 0", true)).to.be.false;
+        expect(isSnakeCase("lower space case", true)).to.be.false;
+        expect(isSnakeCase(" lower space case", true)).to.be.false;
+        expect(isSnakeCase("lower space case ", true)).to.be.false;
+        expect(isSnakeCase("lower  space", true)).to.be.false;
+        expect(isSnakeCase("0 lower space case", true)).to.be.false;
+      });
+    });
+
+    context("an upper space case,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase("Upper Space Case", false)).to.be.false;
+        expect(isSnakeCase(" Upper Space Case", false)).to.be.false;
+        expect(isSnakeCase("Upper Space Case ", false)).to.be.false;
+        expect(isSnakeCase("Upper  Space", false)).to.be.false;
+        expect(isSnakeCase("0 Upper Space Case", false)).to.be.false;
+        expect(isSnakeCase("Upper Space Case", true)).to.be.false;
+        expect(isSnakeCase(" Upper Space Case", true)).to.be.false;
+        expect(isSnakeCase("Upper Space Case ", true)).to.be.false;
+        expect(isSnakeCase("Upper  Space", true)).to.be.false;
+        expect(isSnakeCase("0 Upper Space Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower dot case,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase("0.0", false)).to.be.false;
+        expect(isSnakeCase("lower.dot.case", false)).to.be.false;
+        expect(isSnakeCase(".lower.dot.case", false)).to.be.false;
+        expect(isSnakeCase("lower.dot.case.", false)).to.be.false;
+        expect(isSnakeCase("lower..dot", false)).to.be.false;
+        expect(isSnakeCase("0.lower.dot.case", false)).to.be.false;
+        expect(isSnakeCase("0.0", true)).to.be.false;
+        expect(isSnakeCase("lower.dot.case", true)).to.be.false;
+        expect(isSnakeCase(".lower.dot.case", true)).to.be.false;
+        expect(isSnakeCase("lower.dot.case.", true)).to.be.false;
+        expect(isSnakeCase("lower..dot", true)).to.be.false;
+        expect(isSnakeCase("0.lower.dot.case", true)).to.be.false;
+      });
+    });
+
+    context("an upper dot case,", function() {
+      it("should return false", function() {
+        expect(isSnakeCase("Upper.Dot.Case", false)).to.be.false;
+        expect(isSnakeCase(".Upper.Dot.Case", false)).to.be.false;
+        expect(isSnakeCase("Upper.Dot.Case.", false)).to.be.false;
+        expect(isSnakeCase("Upper..Dot", false)).to.be.false;
+        expect(isSnakeCase("0.Upper.Dot.Case", false)).to.be.false;
+        expect(isSnakeCase("Upper.Dot.Case", true)).to.be.false;
+        expect(isSnakeCase(".Upper.Dot.Case", true)).to.be.false;
+        expect(isSnakeCase("Upper.Dot.Case.", true)).to.be.false;
+        expect(isSnakeCase("Upper..Dot", true)).to.be.false;
+        expect(isSnakeCase("0.Upper.Dot.Case", true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is boolean,", function() {
+    it("should return false", function() {
+      expect(isSnakeCase(true, false)).to.be.false;
+      expect(isSnakeCase(true, true)).to.be.false;
+      expect(isSnakeCase(false, false)).to.be.false;
+      expect(isSnakeCase(false, true)).to.be.false;
+    });
+  });
+
+  context("when a value is array,", function() {
+    it("should return false", function() {
+      expect(isSnakeCase([], false)).to.be.false;
+      expect(isSnakeCase([], true)).to.be.false;
+    });
+  });
+
+  context("when a value is object (pure object/hash/dictionary),", function() {
+    it("should return false", function() {
+      expect(isSnakeCase({}, false)).to.be.false;
+      expect(isSnakeCase({}, true)).to.be.false;
+    });
+  });
+
+  context("when a value is function,", function() {
+    it("should return false", function() {
+      expect(isSnakeCase(() => true, false)).to.be.false;
+      expect(isSnakeCase(() => true, true)).to.be.false;
+    });
+  });
+});

--- a/src/checkers/snake-case-checker.test.ts
+++ b/src/checkers/snake-case-checker.test.ts
@@ -78,6 +78,7 @@ describe("[ Snake Case Checker ]", function() {
         it("should return true", function() {
           expect(isSnakeCase("0", false)).to.be.true;
           expect(isSnakeCase("0_0", false)).to.be.true;
+          expect(isSnakeCase("short", false)).to.be.true;
           expect(isSnakeCase("lower_snake_case", false)).to.be.true;
           expect(isSnakeCase("_lower_snake_case", false)).to.be.false;
           expect(isSnakeCase("lower_snake_case_", false)).to.be.false;
@@ -90,6 +91,7 @@ describe("[ Snake Case Checker ]", function() {
         it("should return false", function() {
           expect(isSnakeCase("0", true)).to.be.true;
           expect(isSnakeCase("0_0", true)).to.be.true;
+          expect(isSnakeCase("short", true)).to.be.false;
           expect(isSnakeCase("lower_snake_case", true)).to.be.false;
           expect(isSnakeCase("_lower_snake_case", true)).to.be.false;
           expect(isSnakeCase("lower_snake_case_", true)).to.be.false;
@@ -102,6 +104,7 @@ describe("[ Snake Case Checker ]", function() {
     context("an upper snake case,", function() {
       context('"isUpper" is false,', function() {
         it("should return false", function() {
+          expect(isSnakeCase("Short", false)).to.be.false;
           expect(isSnakeCase("Upper_Snake_Case", false)).to.be.false;
           expect(isSnakeCase("_Upper_Snake_Case", false)).to.be.false;
           expect(isSnakeCase("Upper_Snake_Case_", false)).to.be.false;
@@ -112,6 +115,7 @@ describe("[ Snake Case Checker ]", function() {
 
       context('"isUpper" is true,', function() {
         it("should return true", function() {
+          expect(isSnakeCase("Short", true)).to.be.true;
           expect(isSnakeCase("Upper_Snake_Case", true)).to.be.true;
           expect(isSnakeCase("_Upper_Snake_Case", true)).to.be.false;
           expect(isSnakeCase("Upper_Snake_Case_", true)).to.be.false;

--- a/src/checkers/snake-case-checker.ts
+++ b/src/checkers/snake-case-checker.ts
@@ -18,8 +18,6 @@ export const isSnakeCase = (value: any, isUpper: boolean) => {
       return false;
   }
 
-  if (stringValue.length === 0) return true;
-
   const wordingPattern = isUpper ? "[0-9A-Z][a-z]*" : "[0-9a-z]+";
   const regExp = new RegExp(`^${wordingPattern}(_${wordingPattern})*$`);
 

--- a/src/checkers/snake-case-checker.ts
+++ b/src/checkers/snake-case-checker.ts
@@ -1,0 +1,27 @@
+// =============================================================================================================================
+// SRC - CHECKERS - SNAKE CASE CHECKER
+// =============================================================================================================================
+export const isSnakeCase = (value: any, isUpper: boolean) => {
+  let stringValue: string = "";
+
+  switch (typeof value) {
+    case "number":
+      stringValue = value.toString();
+
+      break;
+    case "string":
+      if (value.length === 0) return true;
+      stringValue = value;
+
+      break;
+    default:
+      return false;
+  }
+
+  if (stringValue.length === 0) return true;
+
+  const wordingPattern = isUpper ? "[0-9A-Z][a-z]*" : "[0-9a-z]+";
+  const regExp = new RegExp(`^${wordingPattern}(_${wordingPattern})*$`);
+
+  return regExp.test(stringValue);
+};

--- a/src/checkers/space-case-checker.test.ts
+++ b/src/checkers/space-case-checker.test.ts
@@ -1,0 +1,254 @@
+// =============================================================================================================================
+// SRC - CHECKERS - SPACE CASE CHECKER TEST
+// =============================================================================================================================
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
+import { expect } from "chai";
+import { isSpaceCase } from "./space-case-checker";
+
+describe("[ Space Case Checker ]", function() {
+  context("when a value is undefined,", function() {
+    it("should return false", function() {
+      expect(isSpaceCase(undefined, false)).to.be.false;
+      expect(isSpaceCase(undefined, true)).to.be.false;
+    });
+  });
+
+  context("when a value is null,", function() {
+    it("should return false", function() {
+      expect(isSpaceCase(null, false)).to.be.false;
+      expect(isSpaceCase(null, true)).to.be.false;
+    });
+  });
+
+  context("when a value is number,", function() {
+    context("zero,", function() {
+      it("should return true", function() {
+        expect(isSpaceCase(0, false)).to.be.true;
+        expect(isSpaceCase(0, true)).to.be.true;
+      });
+    });
+
+    context("a positive number,", function() {
+      it("should return true", function() {
+        expect(isSpaceCase(1, false)).to.be.true;
+        expect(isSpaceCase(1, true)).to.be.true;
+      });
+    });
+
+    context("a negative number,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase(-1, false)).to.be.false;
+        expect(isSpaceCase(-1, true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is string,", function() {
+    context("an empty string,", function() {
+      it("should return true", function() {
+        expect(isSpaceCase("", false)).to.be.true;
+        expect(isSpaceCase("", true)).to.be.true;
+      });
+    });
+
+    context("a lower camel case,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase("lowerCamelCase", false)).to.be.false;
+        expect(isSpaceCase("lowerCCamel", false)).to.be.false;
+        expect(isSpaceCase("000LowerCamelCase", false)).to.be.false;
+        expect(isSpaceCase("lowerCamelCase", true)).to.be.false;
+        expect(isSpaceCase("lowerCCamel", true)).to.be.false;
+        expect(isSpaceCase("000LowerCamelCase", true)).to.be.false;
+      });
+    });
+
+    context("an upper camel case,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase("UpperCamelCase", false)).to.be.false;
+        expect(isSpaceCase("UpperCCamel", false)).to.be.false;
+        expect(isSpaceCase("000UpperCamelCase", false)).to.be.false;
+        expect(isSpaceCase("UpperCamelCase", true)).to.be.false;
+        expect(isSpaceCase("UpperCCamel", true)).to.be.false;
+        expect(isSpaceCase("000UpperCamelCase", true)).to.be.false;
+      });
+    });
+
+    context("a lower snake case,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase("0_0", false)).to.be.false;
+        expect(isSpaceCase("lower_snake_case", false)).to.be.false;
+        expect(isSpaceCase("_lower_snake_case", false)).to.be.false;
+        expect(isSpaceCase("lower_snake_case_", false)).to.be.false;
+        expect(isSpaceCase("lower__snake", false)).to.be.false;
+        expect(isSpaceCase("0_lower_snake_case", false)).to.be.false;
+        expect(isSpaceCase("0_0", true)).to.be.false;
+        expect(isSpaceCase("lower_snake_case", true)).to.be.false;
+        expect(isSpaceCase("_lower_snake_case", true)).to.be.false;
+        expect(isSpaceCase("lower_snake_case_", true)).to.be.false;
+        expect(isSpaceCase("lower__snake", true)).to.be.false;
+        expect(isSpaceCase("0_lower_snake_case", true)).to.be.false;
+      });
+    });
+
+    context("an upper snake case,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase("Upper_Snake_Case", false)).to.be.false;
+        expect(isSpaceCase("_Upper_Snake_Case", false)).to.be.false;
+        expect(isSpaceCase("Upper_Snake_Case_", false)).to.be.false;
+        expect(isSpaceCase("Upper__Snake", false)).to.be.false;
+        expect(isSpaceCase("0_Upper_Snake_Case", false)).to.be.false;
+        expect(isSpaceCase("Upper_Snake_Case", true)).to.be.false;
+        expect(isSpaceCase("_Upper_Snake_Case", true)).to.be.false;
+        expect(isSpaceCase("Upper_Snake_Case_", true)).to.be.false;
+        expect(isSpaceCase("Upper__Snake", true)).to.be.false;
+        expect(isSpaceCase("0_Upper_Snake_Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower kebab case,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase("0-0", false)).to.be.false;
+        expect(isSpaceCase("lower-kebab-case", false)).to.be.false;
+        expect(isSpaceCase("-lower-kebab-case", false)).to.be.false;
+        expect(isSpaceCase("lower-kebab-case-", false)).to.be.false;
+        expect(isSpaceCase("lower--kebab", false)).to.be.false;
+        expect(isSpaceCase("0-lower-kebab-case", false)).to.be.false;
+        expect(isSpaceCase("0-0", true)).to.be.false;
+        expect(isSpaceCase("lower-kebab-case", true)).to.be.false;
+        expect(isSpaceCase("-lower-kebab-case", true)).to.be.false;
+        expect(isSpaceCase("lower-kebab-case-", true)).to.be.false;
+        expect(isSpaceCase("lower--kebab", true)).to.be.false;
+        expect(isSpaceCase("0-lower-kebab-case", true)).to.be.false;
+      });
+    });
+
+    context("an upper kebab case,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase("Upper-Kebab-Case", false)).to.be.false;
+        expect(isSpaceCase("-Upper-Kebab-Case", false)).to.be.false;
+        expect(isSpaceCase("Upper-Kebab-Case-", false)).to.be.false;
+        expect(isSpaceCase("Upper--Kebab", false)).to.be.false;
+        expect(isSpaceCase("0-Upper-Kebab-Case", false)).to.be.false;
+        expect(isSpaceCase("Upper-Kebab-Case", true)).to.be.false;
+        expect(isSpaceCase("-Upper-Kebab-Case", true)).to.be.false;
+        expect(isSpaceCase("Upper-Kebab-Case-", true)).to.be.false;
+        expect(isSpaceCase("Upper--Kebab", true)).to.be.false;
+        expect(isSpaceCase("0-Upper-Kebab-Case", true)).to.be.false;
+      });
+    });
+
+    context("a lower space case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return true", function() {
+          expect(isSpaceCase("0", false)).to.be.true;
+          expect(isSpaceCase("0 0", false)).to.be.true;
+          expect(isSpaceCase("short", false)).to.be.true;
+          expect(isSpaceCase("lower space case", false)).to.be.true;
+          expect(isSpaceCase(" lower space case", false)).to.be.false;
+          expect(isSpaceCase("lower space case ", false)).to.be.false;
+          expect(isSpaceCase("lower  space", false)).to.be.false;
+          expect(isSpaceCase("0 lower space case", false)).to.be.true;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return false", function() {
+          expect(isSpaceCase("0", true)).to.be.true;
+          expect(isSpaceCase("0 0", true)).to.be.true;
+          expect(isSpaceCase("short", true)).to.be.false;
+          expect(isSpaceCase("lower space case", true)).to.be.false;
+          expect(isSpaceCase(" lower space case", true)).to.be.false;
+          expect(isSpaceCase("lower space case ", true)).to.be.false;
+          expect(isSpaceCase("lower  space", true)).to.be.false;
+          expect(isSpaceCase("0 lower space case", true)).to.be.false;
+        });
+      });
+    });
+
+    context("an upper space case,", function() {
+      context('"isUpper" is false,', function() {
+        it("should return false", function() {
+          expect(isSpaceCase("Short", false)).to.be.false;
+          expect(isSpaceCase("Upper Space Case", false)).to.be.false;
+          expect(isSpaceCase(" Upper Space Case", false)).to.be.false;
+          expect(isSpaceCase("Upper Space Case ", false)).to.be.false;
+          expect(isSpaceCase("Upper  Space", false)).to.be.false;
+          expect(isSpaceCase("0 Upper Space Case", false)).to.be.false;
+        });
+      });
+
+      context('"isUpper" is true,', function() {
+        it("should return true", function() {
+          expect(isSpaceCase("Short", true)).to.be.true;
+          expect(isSpaceCase("Upper Space Case", true)).to.be.true;
+          expect(isSpaceCase(" Upper Space Case", true)).to.be.false;
+          expect(isSpaceCase("Upper Space Case ", true)).to.be.false;
+          expect(isSpaceCase("Upper  Space", true)).to.be.false;
+          expect(isSpaceCase("0 Upper Space Case", true)).to.be.true;
+        });
+      });
+    });
+
+    context("a lower dot case,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase("0.0", false)).to.be.false;
+        expect(isSpaceCase("lower.dot.case", false)).to.be.false;
+        expect(isSpaceCase(".lower.dot.case", false)).to.be.false;
+        expect(isSpaceCase("lower.dot.case.", false)).to.be.false;
+        expect(isSpaceCase("lower..dot", false)).to.be.false;
+        expect(isSpaceCase("0.lower.dot.case", false)).to.be.false;
+        expect(isSpaceCase("0.0", true)).to.be.false;
+        expect(isSpaceCase("lower.dot.case", true)).to.be.false;
+        expect(isSpaceCase(".lower.dot.case", true)).to.be.false;
+        expect(isSpaceCase("lower.dot.case.", true)).to.be.false;
+        expect(isSpaceCase("lower..dot", true)).to.be.false;
+        expect(isSpaceCase("0.lower.dot.case", true)).to.be.false;
+      });
+    });
+
+    context("an upper dot case,", function() {
+      it("should return false", function() {
+        expect(isSpaceCase("Upper.Dot.Case", false)).to.be.false;
+        expect(isSpaceCase(".Upper.Dot.Case", false)).to.be.false;
+        expect(isSpaceCase("Upper.Dot.Case.", false)).to.be.false;
+        expect(isSpaceCase("Upper..Dot", false)).to.be.false;
+        expect(isSpaceCase("0.Upper.Dot.Case", false)).to.be.false;
+        expect(isSpaceCase("Upper.Dot.Case", true)).to.be.false;
+        expect(isSpaceCase(".Upper.Dot.Case", true)).to.be.false;
+        expect(isSpaceCase("Upper.Dot.Case.", true)).to.be.false;
+        expect(isSpaceCase("Upper..Dot", true)).to.be.false;
+        expect(isSpaceCase("0.Upper.Dot.Case", true)).to.be.false;
+      });
+    });
+  });
+
+  context("when a value is boolean,", function() {
+    it("should return false", function() {
+      expect(isSpaceCase(true, false)).to.be.false;
+      expect(isSpaceCase(true, true)).to.be.false;
+      expect(isSpaceCase(false, false)).to.be.false;
+      expect(isSpaceCase(false, true)).to.be.false;
+    });
+  });
+
+  context("when a value is array,", function() {
+    it("should return false", function() {
+      expect(isSpaceCase([], false)).to.be.false;
+      expect(isSpaceCase([], true)).to.be.false;
+    });
+  });
+
+  context("when a value is object (pure object/hash/dictionary),", function() {
+    it("should return false", function() {
+      expect(isSpaceCase({}, false)).to.be.false;
+      expect(isSpaceCase({}, true)).to.be.false;
+    });
+  });
+
+  context("when a value is function,", function() {
+    it("should return false", function() {
+      expect(isSpaceCase(() => true, false)).to.be.false;
+      expect(isSpaceCase(() => true, true)).to.be.false;
+    });
+  });
+});

--- a/src/checkers/space-case-checker.ts
+++ b/src/checkers/space-case-checker.ts
@@ -1,0 +1,25 @@
+// =============================================================================================================================
+// SRC - CHECKERS - SPACE CASE CHECKER
+// =============================================================================================================================
+export const isSpaceCase = (value: any, isUpper: boolean) => {
+  let stringValue: string = "";
+
+  switch (typeof value) {
+    case "number":
+      stringValue = value.toString();
+
+      break;
+    case "string":
+      if (value.length === 0) return true;
+      stringValue = value;
+
+      break;
+    default:
+      return false;
+  }
+
+  const wordingPattern = isUpper ? "[0-9A-Z][a-z]*" : "[0-9a-z]+";
+  const regExp = new RegExp(`^${wordingPattern}(\\s${wordingPattern})*$`);
+
+  return regExp.test(stringValue);
+};

--- a/src/checkers/starts-with-checker.test.ts
+++ b/src/checkers/starts-with-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - STARTS WITH CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { startsWith } from "./starts-with-checker";
 

--- a/src/checkers/type-checker.test.ts
+++ b/src/checkers/type-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - TYPE CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { isType } from "./type-checker";
 

--- a/src/checkers/within-length-range-checker.test.ts
+++ b/src/checkers/within-length-range-checker.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - CHECKERS - WITHIN LENGTH RANGE CHECKER TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import { isWithinLengthRange } from "./within-length-range-checker";
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - INDEX TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import * as sinon from "sinon";
 import marubatsu from "./index";

--- a/src/operators/blank.test.ts
+++ b/src/operators/blank.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - OPERATORS - BLANK TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { createBlankOperator } from "./blank";

--- a/src/operators/empty.test.ts
+++ b/src/operators/empty.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - OPERATORS - EMPTY TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { createEmptyOperator } from "./empty";

--- a/src/operators/nullary.test.ts
+++ b/src/operators/nullary.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - OPERATORS - NULLARY TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { createNullaryOperator } from "./nullary";

--- a/src/operators/present.test.ts
+++ b/src/operators/present.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - OPERATORS - PRESENT TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { createPresentOperator } from "./present";

--- a/src/operators/string.test.ts
+++ b/src/operators/string.test.ts
@@ -182,6 +182,151 @@ describe("[ String ]", function() {
   });
 
   // ---------------------------------------------------------------------------------------------------------------------------
+  // Alphanumeric Rule
+  // ---------------------------------------------------------------------------------------------------------------------------
+  describe("ALPHANUMERIC RULE", function() {
+    context("when an expected value is boolean,", function() {
+      context("true,", function() {
+        it('should be "isAlphanumeric" checker', function() {
+          const isAlphanumeric = sinon.spy();
+          const validators = createStringOperator({ isAlphanumeric })({ alphanumeric: true });
+
+          expect(validators.alphanumeric).to.eq(isAlphanumeric);
+        });
+      });
+
+      context("false,", function() {
+        it("should be undefined", function() {
+          const isAlphanumeric = sinon.spy();
+          const validators = createStringOperator({ isAlphanumeric })({ alphanumeric: false });
+
+          expect(validators.alphanumeric).to.be.undefined;
+        });
+      });
+    });
+
+    context('when an expected value is "lower-camel",', function() {
+      it('should call "isCamelCase" checker and "isUpper" flag is false', function() {
+        const isCamelCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isCamelCase })({ alphanumeric: "lower-camel" });
+
+        validators.alphanumeric(value);
+
+        expect(isCamelCase.calledOnceWith(value, false)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "upper-camel",', function() {
+      it('should call "isCamelCase" checker and "isUpper" flag is true', function() {
+        const isCamelCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isCamelCase })({ alphanumeric: "upper-camel" });
+
+        validators.alphanumeric(value);
+
+        expect(isCamelCase.calledOnceWith(value, true)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "lower-snake",', function() {
+      it('should call "isSnakeCase" checker and "isUpper" flag is false', function() {
+        const isSnakeCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isSnakeCase })({ alphanumeric: "lower-snake" });
+
+        validators.alphanumeric(value);
+
+        expect(isSnakeCase.calledOnceWith(value, false)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "upper-snake",', function() {
+      it('should call "isSnakeCase" checker and "isUpper" flag is true', function() {
+        const isSnakeCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isSnakeCase })({ alphanumeric: "upper-snake" });
+
+        validators.alphanumeric(value);
+
+        expect(isSnakeCase.calledOnceWith(value, true)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "lower-kebab",', function() {
+      it('should call "isKebabCase" checker and "isUpper" flag is false', function() {
+        const isKebabCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isKebabCase })({ alphanumeric: "lower-kebab" });
+
+        validators.alphanumeric(value);
+
+        expect(isKebabCase.calledOnceWith(value, false)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "upper-kebab",', function() {
+      it('should call "isKebabCase" checker and "isUpper" flag is true', function() {
+        const isKebabCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isKebabCase })({ alphanumeric: "upper-kebab" });
+
+        validators.alphanumeric(value);
+
+        expect(isKebabCase.calledOnceWith(value, true)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "lower-space",', function() {
+      it('should call "isSpaceCase" checker and "isUpper" flag is false', function() {
+        const isSpaceCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isSpaceCase })({ alphanumeric: "lower-space" });
+
+        validators.alphanumeric(value);
+
+        expect(isSpaceCase.calledOnceWith(value, false)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "upper-space",', function() {
+      it('should call "isSpaceCase" checker and "isUpper" flag is true', function() {
+        const isSpaceCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isSpaceCase })({ alphanumeric: "upper-space" });
+
+        validators.alphanumeric(value);
+
+        expect(isSpaceCase.calledOnceWith(value, true)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "lower-dot",', function() {
+      it('should call "isDotCase" checker and "isUpper" flag is false', function() {
+        const isDotCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isDotCase })({ alphanumeric: "lower-dot" });
+
+        validators.alphanumeric(value);
+
+        expect(isDotCase.calledOnceWith(value, false)).to.be.true;
+      });
+    });
+
+    context('when an expected value is "upper-dot",', function() {
+      it('should call "isDotCase" checker and "isUpper" flag is true', function() {
+        const isDotCase = sinon.spy();
+        const value = "abcdef";
+        const validators = createStringOperator({ isDotCase })({ alphanumeric: "upper-dot" });
+
+        validators.alphanumeric(value);
+
+        expect(isDotCase.calledOnceWith(value, true)).to.be.true;
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------------------------------------------------------
   // Includes Rule
   // ---------------------------------------------------------------------------------------------------------------------------
   describe("INCLUDES RULE", function() {

--- a/src/operators/string.test.ts
+++ b/src/operators/string.test.ts
@@ -4,7 +4,7 @@
 /* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { allTypeValues } from "./shared.test";
+import { allTypeValues } from "@shared/values.test";
 import { createStringOperator } from "./string";
 
 describe("[ String ]", function() {

--- a/src/operators/string.test.ts
+++ b/src/operators/string.test.ts
@@ -185,16 +185,30 @@ describe("[ String ]", function() {
   // Includes Rule
   // ---------------------------------------------------------------------------------------------------------------------------
   describe("INCLUDES RULE", function() {
-    const value = "abcde";
+    const value = "12345";
 
-    it('should call "checkToIncludes" checker', function() {
-      const checkToIncludes = sinon.spy();
-      const includes = "bcd";
-      const validators = createStringOperator({ checkToIncludes })({ includes });
+    context("when an expected value is number", function() {
+      it('should call "checkToIncludes" checker with the expected value converted to string', function() {
+        const checkToIncludes = sinon.spy();
+        const includes = 234;
+        const validators = createStringOperator({ checkToIncludes })({ includes });
 
-      validators.includes(value);
+        validators.includes(value);
 
-      expect(checkToIncludes.calledOnceWith(value, includes)).to.be.true;
+        expect(checkToIncludes.calledOnceWith(value, includes.toString())).to.be.true;
+      });
+    });
+
+    context("when an expected value is string", function() {
+      it('should call "checkToIncludes" checker with the expected value', function() {
+        const checkToIncludes = sinon.spy();
+        const includes = "234";
+        const validators = createStringOperator({ checkToIncludes })({ includes });
+
+        validators.includes(value);
+
+        expect(checkToIncludes.calledOnceWith(value, includes)).to.be.true;
+      });
     });
   });
 

--- a/src/operators/string.test.ts
+++ b/src/operators/string.test.ts
@@ -26,6 +26,31 @@ describe("[ String ]", function() {
   });
 
   // ---------------------------------------------------------------------------------------------------------------------------
+  // Value Rule
+  // ---------------------------------------------------------------------------------------------------------------------------
+  describe("VALUE RULE", function() {
+    const value = "123";
+
+    context("when an expected value is number", function() {
+      it("should compare a value with the expected value converted to string", function() {
+        const val = 123;
+        const validators = createStringOperator()({ value: val });
+
+        expect(validators.value(value)).to.be.true;
+      });
+    });
+
+    context("when an expected value is string", function() {
+      it("should compare a value with the expected value", function() {
+        const val = "123";
+        const validators = createStringOperator()({ value: val });
+
+        expect(validators.value(value)).to.be.true;
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------------------------------------------------------
   // Length Rule
   // ---------------------------------------------------------------------------------------------------------------------------
   describe("LENGTH RULE", function() {

--- a/src/operators/string.test.ts
+++ b/src/operators/string.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - OPERATORS - STRING TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:only-arrow-functions no-unused-expression no-null-keyword
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { allTypeValues } from "@shared/values.test";

--- a/src/operators/string.ts
+++ b/src/operators/string.ts
@@ -28,7 +28,7 @@ export interface Options {
   minimumLength?: number;
   startsWith?: number | string;
   endsWith?: number | string;
-  includes?: string;
+  includes?: number | string;
   pattern?: RegExp;
 }
 
@@ -80,7 +80,7 @@ export const createStringOperator = (checkers: Partial<DICheckers> = {}) => {
 
     const includes = options.includes;
     if (includes != undefined) {
-      validators.includes = (value: any) => checkToIncludes(value, includes);
+      validators.includes = (value: any) => checkToIncludes(value, includes.toString());
     }
 
     const pattern = options.pattern;

--- a/src/operators/string.ts
+++ b/src/operators/string.ts
@@ -4,8 +4,14 @@
 import {
   endsWith as checkToEndsWith,
   includes as checkToIncludes,
+  isAlphanumeric,
+  isCamelCase,
   isConformingRegExp,
+  isDotCase,
   isEqualToLength,
+  isKebabCase,
+  isSnakeCase,
+  isSpaceCase,
   isType,
   isWithinLengthRange,
   startsWith as checkToStartsWith,
@@ -13,13 +19,31 @@ import {
 import { Validator } from "./shared";
 
 const deafultCheckers = {
+  isAlphanumeric,
+  isCamelCase,
+  isDotCase,
   isEqualToLength,
+  isKebabCase,
+  isSnakeCase,
+  isSpaceCase,
   isWithinLengthRange,
   checkToStartsWith,
   checkToEndsWith,
   checkToIncludes,
   isConformingRegExp,
 };
+
+export type AlphanumericOptionCaseType =
+  | "lower-camel"
+  | "upper-camel"
+  | "lower-snake"
+  | "upper-snake"
+  | "lower-kebab"
+  | "upper-kebab"
+  | "lower-space"
+  | "upper-space"
+  | "lower-dot"
+  | "upper-dot";
 
 export interface Options {
   value?: number | string;
@@ -28,6 +52,7 @@ export interface Options {
   minimumLength?: number;
   startsWith?: number | string;
   endsWith?: number | string;
+  alphanumeric?: boolean | AlphanumericOptionCaseType;
   includes?: number | string;
   pattern?: RegExp;
 }
@@ -35,7 +60,20 @@ export interface Options {
 type DICheckers = { [K in keyof typeof deafultCheckers]: typeof deafultCheckers[K] };
 export const createStringOperator = (checkers: Partial<DICheckers> = {}) => {
   // tslint:disable:no-shadowed-variable
-  const { isEqualToLength, isWithinLengthRange, checkToStartsWith, checkToEndsWith, checkToIncludes, isConformingRegExp } = {
+  const {
+    isAlphanumeric,
+    isCamelCase,
+    isDotCase,
+    isEqualToLength,
+    isKebabCase,
+    isSnakeCase,
+    isSpaceCase,
+    isWithinLengthRange,
+    checkToStartsWith,
+    checkToEndsWith,
+    checkToIncludes,
+    isConformingRegExp,
+  } = {
     ...deafultCheckers,
     ...checkers,
   };
@@ -76,6 +114,42 @@ export const createStringOperator = (checkers: Partial<DICheckers> = {}) => {
     const endsWith = options.endsWith;
     if (endsWith != undefined) {
       validators.endsWith = (value: any) => checkToEndsWith(value, endsWith.toString());
+    }
+
+    const alphanumeric = options.alphanumeric;
+    if (alphanumeric != undefined) {
+      if (alphanumeric === true) {
+        validators.alphanumeric = isAlphanumeric;
+      } else {
+        switch (alphanumeric) {
+          case "lower-camel":
+          case "upper-camel":
+            validators.alphanumeric = (value: any) => isCamelCase(value, alphanumeric === "upper-camel");
+
+            break;
+          case "lower-snake":
+          case "upper-snake":
+            validators.alphanumeric = (value: any) => isSnakeCase(value, alphanumeric === "upper-snake");
+
+            break;
+          case "lower-kebab":
+          case "upper-kebab":
+            validators.alphanumeric = (value: any) => isKebabCase(value, alphanumeric === "upper-kebab");
+
+            break;
+          case "lower-space":
+          case "upper-space":
+            validators.alphanumeric = (value: any) => isSpaceCase(value, alphanumeric === "upper-space");
+
+            break;
+          case "lower-dot":
+          case "upper-dot":
+            validators.alphanumeric = (value: any) => isDotCase(value, alphanumeric === "upper-dot");
+
+            break;
+          default:
+        }
+      }
     }
 
     const includes = options.includes;

--- a/src/operators/string.ts
+++ b/src/operators/string.ts
@@ -22,6 +22,7 @@ const deafultCheckers = {
 };
 
 export interface Options {
+  value?: number | string;
   length?: number | [number, number];
   maximumLength?: number;
   minimumLength?: number;
@@ -44,6 +45,11 @@ export const createStringOperator = (checkers: Partial<DICheckers> = {}) => {
     const validators: Validator = {
       type: (value: any) => isType(value, "string"),
     };
+
+    const val = options.value;
+    if (val != undefined) {
+      validators.value = (value: any) => val.toString() === value;
+    }
 
     const length = options.length;
     if (length != undefined) {

--- a/src/shared/values.test.ts
+++ b/src/shared/values.test.ts
@@ -1,7 +1,7 @@
 // =============================================================================================================================
 // SRC - SHARED - VALUES TEST
 // =============================================================================================================================
-/* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
+// tslint:disable:no-null-keyword
 export const allTypeValues = [undefined, null, 123, "abc", true, [1, 2, 3], { a: 1, b: 2 }, () => true];
 
 export const allValues = [

--- a/src/shared/values.test.ts
+++ b/src/shared/values.test.ts
@@ -1,5 +1,5 @@
 // =============================================================================================================================
-// SRC - OPERATORS - SHARED TEST
+// SRC - SHARED - VALUES TEST
 // =============================================================================================================================
 /* tslint:disable:only-arrow-functions no-unused-expression no-null-keyword */
 export const allTypeValues = [undefined, null, 123, "abc", true, [1, 2, 3], { a: 1, b: 2 }, () => true];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "moduleResolution": "node",
     "outDir": "./.dist",
     "paths": {
+      "@shared/*": ["./src/shared/*"],
       "@checkers/*": ["./src/checkers/*"],
       "@rules/*": ["./src/rules/*"]
     },


### PR DESCRIPTION
# New Features
- Add about "nullary", "empty", "blank", and "present" operators to a readme
- Add "value" rule to "string" operator in order to check a value is equal to a specific number or string
- Add support for passing number value to "includes" rule of "string" operator
- Add "isAlphanumeric" checker to "string" operator in order to check a value is alphanumeric
- Add path alias `@shared`
  - Move a shared value definitions file for tests to `@shared` directory
- Add a custom code snippet to insert `import {} from "@shared"` easily
- Add "isCamelCase" checker to "string" operator in order to check a value is lowerCamelCase or UpperCamelCase
- Add "isSnakeCase" checker to "string" operator in order to check a value is lower_snake_case or Upper_Snake_Case
- Add "isKebabCase" checker to "string" operator in order to check a value is lower-kebab-case or Upper-Kebab-Case
- Add "isSpaceCase" checker to "string" operator in order to check a value is lower space case or Upper Space Case
- Add "isDotCase" checker to "string" operator in order to check a value is lower.dot.case or Upper.Dot.Case
- Add "alphanumeric" rule to "string" operator in order to check a value is alphanumeric and a specific case style
- Add about "alphanumeric" rule of "string" operator to a readme file


# Changes and Fixes
- Modify English in a readme
- Modify tests of `isBlank` checker
- Modify usage of "startsWith" rule of "string" operator in a readme


# Refactors
- Modify context messages in some tests for some checkers
