### PR TITLE
Change argument types of string operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ const isValidWebsite = marubatsu()
   - [`blank()`](#blank)
   - [`present()`](#present)
   - [`string(rules: { [ruleName]: any } = {})`](#stringrules--rulename-any---)
-    - [`value: number | string`](#value-number--string)
+    - [`value: string`](#value-string)
     - [`length: number`](#length-number)
     - [`length: [number, number]`](#length-number-number)
     - [`maximumLength: number`](#maximumlength-number)
     - [`minimumLength: number`](#minimumlength-number)
-    - [`startsWith: number | string`](#startswith-number--string)
-    - [`endsWith: number | string`](#endswith-number--string)
+    - [`startsWith: string`](#startswith-string)
+    - [`endsWith: string`](#endswith-string)
     - [`alphanumeric: boolean`](#alphanumeric-boolean)
     - [`alphanumeric: "lower-camel" | "upper-camel" | "lower-snake" | "upper-snake" | "lower-kebab" | "upper-kebab" | "lower-space" | "upper-space" | "lower-dot" | "upper-dot"`](#alphanumeric-lower-camel--upper-camel--lower-snake--upper-snake--lower-kebab--upper-kebab--lower-space--upper-space--lower-dot--upper-dot)
-    - [`includes: number | string`](#includes-number--string)
+    - [`includes: string`](#includes-string)
     - [`pattern: RegExp`](#pattern-regexp)
 - [Options](#options)
     - [`checkAll: boolean = false`](#checkall-boolean--false)
@@ -296,8 +296,8 @@ validator.test("ok"); // true
 validator.test(123);  // false
 ```
 
-#### `value: number | string`
-Checks the string is equal to a specific number or string. If passing number, it will be converted to string.
+#### `value: string`
+Checks the string is equal to a specific number or string.
 
 ```ts
 const validator = marubatsu().string({ value: 123 });
@@ -353,8 +353,8 @@ validator.test("1234"); // true
 ```
 
 
-#### `startsWith: number | string`
-Checks the string is starting with a specific number or string. If passing number, it will be converted to string.
+#### `startsWith: string`
+Checks the string is starting with a specific number or string.
 
 ```ts
 const validator = marubatsu().string({ startsWith: 1 });
@@ -364,8 +364,8 @@ validator.test("231"); // false
 validator.test("321"); // false
 ```
 
-#### `endsWith: number | string`
-Checks the string is ending with a specific number or string. If passing number, it will be converted to string.
+#### `endsWith: string`
+Checks the string is ending with a specific number or string.
 
 ```ts
 const validator = marubatsu().string({ endsWith: 1 });
@@ -416,8 +416,8 @@ validator.test("jaga-apple"); // false
 validator.test("jaga.apple"); // false
 ```
 
-#### `includes: number | string`
-Checks the string includes a specific number or string. If passing number, it will be converted to string.
+#### `includes: string`
+Checks the string includes a specific number or string.
 
 ```ts
 const validator = marubatsu().string({ includes: "am" });

--- a/src/checkers/ends-with-checker.test.ts
+++ b/src/checkers/ends-with-checker.test.ts
@@ -35,26 +35,10 @@ describe("[ Ends With Checker ]", function() {
   });
 
   context("when a target value is number,", function() {
-    context("ending with an expected value,", function() {
-      it("should return true", function() {
-        expect(endsWith(0, "0")).to.be.true;
-        expect(endsWith(12345, "345")).to.be.true;
-      });
-    });
-
-    context("not ending with an expected value,", function() {
-      it("should return false", function() {
-        expect(endsWith(12345, "ber")).to.be.false;
-        expect(endsWith(12345, "cde")).to.be.false;
-        expect(endsWith(12345, "123")).to.be.false;
-      });
-    });
-
-    context("an expected value is an empty string,", function() {
-      it("should return true", function() {
-        expect(endsWith(0, "")).to.be.true;
-        expect(endsWith(12345, "")).to.be.true;
-      });
+    it("should return false", function() {
+      expect(endsWith(12345, "345")).to.be.false;
+      expect(endsWith(12345, "ber")).to.be.false;
+      expect(endsWith(12345, "cde")).to.be.false;
     });
   });
 

--- a/src/checkers/ends-with-checker.ts
+++ b/src/checkers/ends-with-checker.ts
@@ -7,10 +7,6 @@ export const endsWith = (value: any, expectedValue: string) => {
   let stringValue: string = "";
 
   switch (typeof value) {
-    case "number":
-      stringValue = value.toString();
-
-      break;
     case "string":
       stringValue = value;
 

--- a/src/checkers/includes-checker.test.ts
+++ b/src/checkers/includes-checker.test.ts
@@ -21,18 +21,9 @@ describe("[ Includes Checker ]", function() {
   });
 
   context("when a target value is number,", function() {
-    context("including an expected number,", function() {
-      it("should return true", function() {
-        expect(includes(0, "0")).to.be.true;
-        expect(includes(12345, "234")).to.be.true;
-      });
-    });
-
-    context("not including an expected number,", function() {
-      it("should return false", function() {
-        expect(includes(12345, "0")).to.be.false;
-        expect(includes(12345, "56")).to.be.false;
-      });
+    it("should return false", function() {
+      expect(includes(0, "0")).to.be.false;
+      expect(includes(12345, "234")).to.be.false;
     });
   });
 

--- a/src/checkers/includes-checker.ts
+++ b/src/checkers/includes-checker.ts
@@ -7,10 +7,6 @@ export const includes = (value: any, expectedValue: string) => {
   let checkableValue: string | any[] = "";
 
   switch (typeof value) {
-    case "number":
-      checkableValue = value.toString();
-
-      break;
     case "string":
       checkableValue = value;
 

--- a/src/checkers/starts-with-checker.test.ts
+++ b/src/checkers/starts-with-checker.test.ts
@@ -35,26 +35,10 @@ describe("[ Starts With Checker ]", function() {
   });
 
   context("when a target value is number,", function() {
-    context("starting with an expected value,", function() {
-      it("should return true", function() {
-        expect(startsWith(0, "0")).to.be.true;
-        expect(startsWith(12345, "123")).to.be.true;
-      });
-    });
-
-    context("not starting with an expected value,", function() {
-      it("should return false", function() {
-        expect(startsWith(12345, "num")).to.be.false;
-        expect(startsWith(12345, "abc")).to.be.false;
-        expect(startsWith(12345, "345")).to.be.false;
-      });
-    });
-
-    context("an expected value is an empty string,", function() {
-      it("should return true", function() {
-        expect(startsWith(0, "")).to.be.true;
-        expect(startsWith(12345, "")).to.be.true;
-      });
+    it("should return false", function() {
+      expect(startsWith(12345, "123")).to.be.false;
+      expect(startsWith(12345, "num")).to.be.false;
+      expect(startsWith(12345, "abc")).to.be.false;
     });
   });
 

--- a/src/checkers/starts-with-checker.ts
+++ b/src/checkers/starts-with-checker.ts
@@ -7,10 +7,6 @@ export const startsWith = (value: any, expectedValue: string) => {
   let stringValue: string = "";
 
   switch (typeof value) {
-    case "number":
-      stringValue = value.toString();
-
-      break;
     case "string":
       stringValue = value;
 

--- a/src/operators/string.test.ts
+++ b/src/operators/string.test.ts
@@ -30,22 +30,11 @@ describe("[ String ]", function() {
   // Value Rule
   // ---------------------------------------------------------------------------------------------------------------------------
   describe("VALUE RULE", function() {
-    context("when an expected value is number,", function() {
-      it("should compare the number converted to string with the expected value,", function() {
-        const val = 123;
-        const validators = createStringOperator()({ value: val });
+    it("should compare the string with the expected value", function() {
+      const val = "123";
+      const validators = createStringOperator()({ value: val });
 
-        expect(validators.value(targetValue)).to.be.true;
-      });
-    });
-
-    context("when an expected value is string,", function() {
-      it("should compare the string with the expected value", function() {
-        const val = "123";
-        const validators = createStringOperator()({ value: val });
-
-        expect(validators.value(targetValue)).to.be.true;
-      });
+      expect(validators.value(targetValue)).to.be.true;
     });
   });
 
@@ -116,28 +105,14 @@ describe("[ String ]", function() {
   // Starts With Rule
   // ---------------------------------------------------------------------------------------------------------------------------
   describe("STARTS WITH RULE", function() {
-    context("when an expected value is number,", function() {
-      it('should call "checkToStartsWith" checker with an expected value converted to string', function() {
-        const checkToStartsWith = sinon.spy();
-        const startsWith = 123;
-        const validators = createStringOperator({ checkToStartsWith })({ startsWith });
+    it('should call "checkToStartsWith" checker with an expected value', function() {
+      const checkToStartsWith = sinon.spy();
+      const startsWith = "123";
+      const validators = createStringOperator({ checkToStartsWith })({ startsWith });
 
-        validators.startsWith(targetValue);
+      validators.startsWith(targetValue);
 
-        expect(checkToStartsWith.calledOnceWith(targetValue, startsWith.toString())).to.be.true;
-      });
-    });
-
-    context("when an expected value is string,", function() {
-      it('should call "checkToStartsWith" checker with an expected value', function() {
-        const checkToStartsWith = sinon.spy();
-        const startsWith = "123";
-        const validators = createStringOperator({ checkToStartsWith })({ startsWith });
-
-        validators.startsWith(targetValue);
-
-        expect(checkToStartsWith.calledOnceWith(targetValue, startsWith)).to.be.true;
-      });
+      expect(checkToStartsWith.calledOnceWith(targetValue, startsWith)).to.be.true;
     });
   });
 
@@ -145,28 +120,14 @@ describe("[ String ]", function() {
   // Ends With Rule
   // ---------------------------------------------------------------------------------------------------------------------------
   describe("ENDS WITH RULE", function() {
-    context("when an expected value is number,", function() {
-      it('should call "checkToEndsWith" checker with an expected value converted to string', function() {
-        const checkToEndsWith = sinon.spy();
-        const endsWith = 345;
-        const validators = createStringOperator({ checkToEndsWith })({ endsWith });
+    it('should call "checkToEndsWith" checker with an expected value', function() {
+      const checkToEndsWith = sinon.spy();
+      const endsWith = "345";
+      const validators = createStringOperator({ checkToEndsWith })({ endsWith });
 
-        validators.endsWith(targetValue);
+      validators.endsWith(targetValue);
 
-        expect(checkToEndsWith.calledOnceWith(targetValue, endsWith.toString())).to.be.true;
-      });
-    });
-
-    context("when an expected value is string,", function() {
-      it('should call "checkToEndsWith" checker with an expected value', function() {
-        const checkToEndsWith = sinon.spy();
-        const endsWith = "345";
-        const validators = createStringOperator({ checkToEndsWith })({ endsWith });
-
-        validators.endsWith(targetValue);
-
-        expect(checkToEndsWith.calledOnceWith(targetValue, endsWith)).to.be.true;
-      });
+      expect(checkToEndsWith.calledOnceWith(targetValue, endsWith)).to.be.true;
     });
   });
 
@@ -309,28 +270,14 @@ describe("[ String ]", function() {
   // Includes Rule
   // ---------------------------------------------------------------------------------------------------------------------------
   describe("INCLUDES RULE", function() {
-    context("when an expected value is number,", function() {
-      it('should call "checkToIncludes" checker with the expected value converted to string', function() {
-        const checkToIncludes = sinon.spy();
-        const includes = 234;
-        const validators = createStringOperator({ checkToIncludes })({ includes });
+    it('should call "checkToIncludes" checker with the expected value', function() {
+      const checkToIncludes = sinon.spy();
+      const includes = "234";
+      const validators = createStringOperator({ checkToIncludes })({ includes });
 
-        validators.includes(targetValue);
+      validators.includes(targetValue);
 
-        expect(checkToIncludes.calledOnceWith(targetValue, includes.toString())).to.be.true;
-      });
-    });
-
-    context("when an expected value is string,", function() {
-      it('should call "checkToIncludes" checker with the expected value', function() {
-        const checkToIncludes = sinon.spy();
-        const includes = "234";
-        const validators = createStringOperator({ checkToIncludes })({ includes });
-
-        validators.includes(targetValue);
-
-        expect(checkToIncludes.calledOnceWith(targetValue, includes)).to.be.true;
-      });
+      expect(checkToIncludes.calledOnceWith(targetValue, includes)).to.be.true;
     });
   });
 

--- a/src/operators/string.ts
+++ b/src/operators/string.ts
@@ -46,14 +46,14 @@ export type AlphanumericOptionCaseType =
   | "upper-dot";
 
 export interface Options {
-  value?: number | string;
+  value?: string;
   length?: number | [number, number];
   maximumLength?: number;
   minimumLength?: number;
-  startsWith?: number | string;
-  endsWith?: number | string;
+  startsWith?: string;
+  endsWith?: string;
   alphanumeric?: boolean | AlphanumericOptionCaseType;
-  includes?: number | string;
+  includes?: string;
   pattern?: RegExp;
 }
 
@@ -86,7 +86,7 @@ export const createStringOperator = (checkers: Partial<DICheckers> = {}) => {
 
     const val = options.value;
     if (val != undefined) {
-      validators.value = (value: any) => val.toString() === value;
+      validators.value = (value: any) => val === value;
     }
 
     const length = options.length;


### PR DESCRIPTION
# Changes and Fixes
- Make "value", "startsWith", "endsWith", and "includes" rules of string operator to accept only string value
- Update a readme
